### PR TITLE
fix issue with snapstart and loading mappings; and priming

### DIFF
--- a/.kiro/specs/snapstart-mapping-reload/.config.kiro
+++ b/.kiro/specs/snapstart-mapping-reload/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "e57a84af-596d-4106-a995-757cb82b0d12", "workflowType": "requirements-first", "specType": "bugfix"}

--- a/.kiro/specs/snapstart-mapping-reload/bugfix.md
+++ b/.kiro/specs/snapstart-mapping-reload/bugfix.md
@@ -1,0 +1,226 @@
+# Bugfix Requirements Document
+
+## Introduction
+
+This document covers two related SnapStart bugs in the MockNest Serverless Lambda architecture:
+
+**Bug 1 — Stale mappings after SnapStart restore:** After enabling SnapStart on the Runtime Lambda, WireMock mock mappings are not available on cold start (restore from snapshot). The mappings are loaded once during Spring context initialization (`server.start()` → `ObjectStorageMappingsSource.loadMappingsInto()`), but SnapStart takes its snapshot *after* this initialization. When the snapshot is restored for a new invocation, the in-memory WireMock state is from snapshot time — which may be empty or stale relative to what is currently in S3. The current `RuntimePrimingHook` only exercises the WireMock engine during snapshot creation but has no `afterRestore` hook to reload mappings from S3 after each restore. Calling `/__admin/mappings/reset` manually triggers a reload and fixes the issue, confirming the mappings exist in S3 but are simply not loaded into memory post-restore.
+
+**Bug 2 — Priming hook cross-contamination caused by the generic `aws` profile:** All three Lambda functions share the same JAR (`mocknest-serverless.jar`) and `MockNestApplication` main class. The SAM template `Globals` section sets `SPRING_PROFILES_ACTIVE: aws` for all functions, and only the Async Lambda overrides this with `SPRING_PROFILES_ACTIVE: "core,async"`. The `aws` profile is a generic cloud-provider label that does not differentiate between Lambda capabilities. Both `RuntimePrimingHook` (`@Profile("!async")`) and `GenerationPrimingHook` (`@Profile("!async")`) use the same negation-based profile exclusion, so both hooks fire on both the Runtime and Generation Lambdas. Similarly, `MockNestConfig` (which wires the WireMock server, `DirectCallHttpServer`, and related beans) uses `@Profile("!async")`, meaning it also loads on the Generation Lambda where WireMock is not needed.
+
+The fix replaces the generic `aws` profile with three capability-specific Spring profiles that map 1:1 to the three Lambda functions:
+- **`runtime`** — for the Runtime Lambda (serves mock responses, WireMock engine)
+- **`generation`** — for the Generation Lambda (AI mock generation via Bedrock)
+- **`async`** — for the Async Lambda (webhook dispatch via SQS) — already exists and works correctly
+
+This makes `@Profile` annotations self-documenting and eliminates the need for negation-based exclusions like `@Profile("!async")`.
+
+## Bug Analysis
+
+### Current Behavior (Defect)
+
+1.1 WHEN SnapStart restores a Lambda snapshot and a mock request arrives THEN the system returns no match (404 or WireMock "no matching stub" response) because in-memory mappings from snapshot time are stale or empty
+
+1.2 WHEN SnapStart restores a Lambda snapshot THEN the system does not execute any post-restore logic to reload mappings from S3 into WireMock's in-memory stub store
+
+1.3 WHEN a user manually calls `/__admin/mappings/reset` after a SnapStart restore THEN the system correctly loads all mappings from S3, confirming the mappings exist in storage but were not loaded automatically
+
+1.4 WHEN the Runtime Lambda starts with `SPRING_PROFILES_ACTIVE: aws` (inherited from SAM Globals) THEN both `RuntimePrimingHook` and `GenerationPrimingHook` are activated because both use `@Profile("!async")` and the generic `aws` profile does not differentiate between Lambda capabilities
+
+1.5 WHEN the Generation Lambda starts with `SPRING_PROFILES_ACTIVE: aws` (inherited from SAM Globals) THEN both `GenerationPrimingHook` and `RuntimePrimingHook` are activated because both use `@Profile("!async")` and the generic `aws` profile does not differentiate between Lambda capabilities
+
+1.6 WHEN `RuntimePrimingHook` fires on the Generation Lambda THEN the system attempts to exercise WireMock engine components (stub creation, request matching, journal suppression) that are irrelevant to the Generation Lambda's purpose, wasting snapshot creation time and potentially causing errors if WireMock beans are not available
+
+1.7 WHEN `GenerationPrimingHook` fires on the Runtime Lambda THEN the system attempts to warm up Bedrock clients, AI model configuration, specification parsers, and prompt builders that are irrelevant to the Runtime Lambda's purpose, wasting snapshot creation time and increasing snapshot size
+
+1.8 WHEN `MockNestConfig` loads on the Generation Lambda (because it uses `@Profile("!async")` and the `aws` profile does not include `async`) THEN the system unnecessarily wires WireMock server, `DirectCallHttpServer`, and related beans on a Lambda that only needs Bedrock/AI components
+
+### Expected Behavior (Correct)
+
+2.1 WHEN SnapStart restores a Lambda snapshot and a mock request arrives THEN the system SHALL return the correct mock response because mappings have been automatically reloaded from S3 after restore
+
+2.2 WHEN SnapStart restores a Lambda snapshot THEN the system SHALL execute a post-restore hook (CRaC `afterRestore` or equivalent) that reloads all mappings from S3 into WireMock's in-memory stub store
+
+2.3 WHEN a user calls `/__admin/mappings/reset` after a SnapStart restore THEN the system SHALL continue to reload mappings from S3 as before (manual reset remains functional)
+
+2.4 WHEN the Runtime Lambda starts with `SPRING_PROFILES_ACTIVE: runtime` THEN only `RuntimePrimingHook` (annotated `@Profile("runtime")`) SHALL be activated; `GenerationPrimingHook` SHALL NOT be activated on the Runtime Lambda
+
+2.5 WHEN the Generation Lambda starts with `SPRING_PROFILES_ACTIVE: generation` THEN only `GenerationPrimingHook` (annotated `@Profile("generation")`) SHALL be activated; `RuntimePrimingHook` SHALL NOT be activated on the Generation Lambda
+
+2.6 WHEN the post-restore mapping reload executes THEN it SHALL only run on the Runtime Lambda (scoped via `@Profile("runtime")`), not on the Generation Lambda or Async Lambda
+
+2.7 WHEN `MockNestConfig` is evaluated on the Generation Lambda THEN it SHALL NOT load because it uses `@Profile("runtime")`, and the Generation Lambda's active profile is `generation`
+
+2.8 WHEN the SAM template deploys the Runtime Lambda THEN its environment SHALL set `SPRING_PROFILES_ACTIVE: runtime` instead of inheriting the global `aws` profile
+
+2.9 WHEN the SAM template deploys the Generation Lambda THEN its environment SHALL set `SPRING_PROFILES_ACTIVE: generation` instead of inheriting the global `aws` profile
+
+2.10 WHEN the SAM template `Globals` section is evaluated THEN `SPRING_PROFILES_ACTIVE` SHALL either be removed from Globals or set to a base value that does not activate capability-specific beans, since each Lambda now declares its own profile
+
+2.11 WHEN a Spring integration test runs with `@ActiveProfiles("runtime")` THEN the application context SHALL contain `RuntimePrimingHook`, `MockNestConfig`, `WireMockServer`, `DirectCallHttpServer`, and the post-restore mapping reload hook, AND SHALL NOT contain `GenerationPrimingHook` or generation-specific beans (Bedrock clients, AI model configuration, specification parsers, prompt builders)
+
+2.12 WHEN a Spring integration test runs with `@ActiveProfiles("generation")` THEN the application context SHALL contain `GenerationPrimingHook` and generation-specific beans (Bedrock clients, AI model configuration, specification parsers, prompt builders), AND SHALL NOT contain `RuntimePrimingHook`, `MockNestConfig`, `WireMockServer`, `DirectCallHttpServer`, or the post-restore mapping reload hook
+
+2.13 WHEN a Spring integration test runs with `@ActiveProfiles("core", "async")` THEN the application context SHALL NOT contain `RuntimePrimingHook`, `GenerationPrimingHook`, `MockNestConfig`, or the post-restore mapping reload hook — confirming the async Lambda remains isolated from both runtime and generation components
+
+### Unchanged Behavior (Regression Prevention)
+
+3.1 WHEN the Lambda performs a normal (non-SnapStart) cold start THEN the system SHALL CONTINUE TO load mappings from S3 during `server.start()` via `ObjectStorageMappingsSource.loadMappingsInto()` as it does today
+
+3.2 WHEN the SnapStart snapshot is being created THEN the system SHALL CONTINUE TO execute the existing priming logic (health check warm-up, S3 client initialization, WireMock engine exercise) without attempting to load production mappings at snapshot time
+
+3.3 WHEN the WireMock engine is exercised during SnapStart priming THEN the system SHALL CONTINUE TO suppress S3 journal writes and clean up the temporary test mapping afterward
+
+3.4 WHEN a mock request arrives on a non-SnapStart Lambda invocation THEN the system SHALL CONTINUE TO match and serve mock responses using the mappings loaded at startup
+
+3.5 WHEN mappings are saved, removed, or modified via the WireMock admin API THEN the system SHALL CONTINUE TO persist those changes to S3 via `ObjectStorageMappingsSource`
+
+3.6 WHEN the Async Lambda starts with `SPRING_PROFILES_ACTIVE: "core,async"` THEN the system SHALL CONTINUE TO exclude both `RuntimePrimingHook` and `GenerationPrimingHook` and `MockNestConfig` — the Async Lambda's profile configuration is unchanged
+
+3.7 WHEN the Generation Lambda starts with `SPRING_PROFILES_ACTIVE: generation` THEN `GenerationPrimingHook` SHALL CONTINUE TO warm up Bedrock clients, AI model configuration, specification parsers, prompt builders, mock validators, SOAP/WSDL components, and GraphQL components as it does today
+
+3.8 WHEN the Runtime Lambda starts with `SPRING_PROFILES_ACTIVE: runtime` THEN `RuntimePrimingHook` SHALL CONTINUE TO warm up health check, S3 client, and WireMock engine as it does today
+
+---
+
+## Bug Condition
+
+### Bug Condition Function
+
+```pascal
+FUNCTION isBugCondition(X)
+  INPUT: X of type LambdaInvocation
+  OUTPUT: boolean
+  
+  // Bug condition 1: SnapStart restore without mapping reload
+  LET isSnapStartRestore = X.isSnapStartRestore = true
+  
+  // Bug condition 2: Priming hook cross-contamination due to generic "aws" profile
+  //   - Runtime Lambda activating GenerationPrimingHook (both use @Profile("!async"), both get "aws" profile)
+  //   - Generation Lambda activating RuntimePrimingHook (same reason)
+  //   - Generation Lambda loading MockNestConfig (uses @Profile("!async"), "aws" profile doesn't exclude it)
+  LET isCrossContamination = (X.lambdaType = "runtime" AND X.activatedHooks CONTAINS "GenerationPrimingHook")
+                          OR (X.lambdaType = "generation" AND X.activatedHooks CONTAINS "RuntimePrimingHook")
+                          OR (X.lambdaType = "generation" AND X.activatedBeans CONTAINS "MockNestConfig")
+  
+  RETURN isSnapStartRestore OR isCrossContamination
+END FUNCTION
+```
+
+### Property Specification — Fix Checking
+
+```pascal
+// Property 1: Fix Checking — Mappings reloaded after SnapStart restore
+FOR ALL X WHERE X.isSnapStartRestore = true AND X.lambdaType = "runtime" DO
+  result ← invokeRuntime'(X)
+  ASSERT wireMockStubStore(result).mappings = S3MappingsSource.loadAll()
+  ASSERT matchingRequest(result) ≠ "no matching stub"
+END FOR
+
+// Property 2: Fix Checking — Priming hook isolation via capability-specific profiles
+FOR ALL X WHERE X.lambdaType = "runtime" AND X.profile = "runtime" DO
+  hooks ← activatedHooks'(X)
+  ASSERT "RuntimePrimingHook" ∈ hooks
+  ASSERT "GenerationPrimingHook" ∉ hooks
+END FOR
+
+FOR ALL X WHERE X.lambdaType = "generation" AND X.profile = "generation" DO
+  hooks ← activatedHooks'(X)
+  ASSERT "GenerationPrimingHook" ∈ hooks
+  ASSERT "RuntimePrimingHook" ∉ hooks
+END FOR
+
+// Property 3: Fix Checking — MockNestConfig scoped to runtime profile only
+FOR ALL X WHERE X.lambdaType = "generation" AND X.profile = "generation" DO
+  beans ← activatedBeans'(X)
+  ASSERT "MockNestConfig" ∉ beans
+END FOR
+
+FOR ALL X WHERE X.lambdaType = "runtime" AND X.profile = "runtime" DO
+  beans ← activatedBeans'(X)
+  ASSERT "MockNestConfig" ∈ beans
+END FOR
+
+// Property 4: Fix Checking — Post-restore reload scoped to runtime only
+FOR ALL X WHERE X.isSnapStartRestore = true AND X.lambdaType = "generation" DO
+  ASSERT postRestoreMappingReload(X) = false
+END FOR
+
+// Property 5: Fix Checking — Spring integration tests verify profile-based bean wiring
+// These @SpringBootTest tests catch profile misconfiguration at test time rather than in production.
+
+FOR ALL TestContext WHERE TestContext.activeProfiles = {"runtime"} DO
+  beans ← applicationContext'(TestContext)
+  ASSERT "RuntimePrimingHook" ∈ beans
+  ASSERT "MockNestConfig" ∈ beans
+  ASSERT "WireMockServer" ∈ beans
+  ASSERT "DirectCallHttpServer" ∈ beans
+  ASSERT "postRestoreMappingReloadHook" ∈ beans
+  ASSERT "GenerationPrimingHook" ∉ beans
+  ASSERT "BedrockRuntimeClient" ∉ beans
+  ASSERT "ModelConfiguration" ∉ beans
+  ASSERT "OpenAPISpecificationParser" ∉ beans
+  ASSERT "PromptBuilderService" ∉ beans
+END FOR
+
+FOR ALL TestContext WHERE TestContext.activeProfiles = {"generation"} DO
+  beans ← applicationContext'(TestContext)
+  ASSERT "GenerationPrimingHook" ∈ beans
+  ASSERT "BedrockRuntimeClient" ∈ beans
+  ASSERT "ModelConfiguration" ∈ beans
+  ASSERT "OpenAPISpecificationParser" ∈ beans
+  ASSERT "PromptBuilderService" ∈ beans
+  ASSERT "RuntimePrimingHook" ∉ beans
+  ASSERT "MockNestConfig" ∉ beans
+  ASSERT "WireMockServer" ∉ beans
+  ASSERT "DirectCallHttpServer" ∉ beans
+  ASSERT "postRestoreMappingReloadHook" ∉ beans
+END FOR
+
+FOR ALL TestContext WHERE TestContext.activeProfiles = {"core", "async"} DO
+  beans ← applicationContext'(TestContext)
+  ASSERT "RuntimePrimingHook" ∉ beans
+  ASSERT "GenerationPrimingHook" ∉ beans
+  ASSERT "MockNestConfig" ∉ beans
+  ASSERT "postRestoreMappingReloadHook" ∉ beans
+END FOR
+
+// Property 6: Fix Checking — SAM template profile assignment
+FOR ALL Lambda WHERE Lambda.name = "Runtime" DO
+  ASSERT Lambda.environment.SPRING_PROFILES_ACTIVE = "runtime"
+END FOR
+
+FOR ALL Lambda WHERE Lambda.name = "Generation" DO
+  ASSERT Lambda.environment.SPRING_PROFILES_ACTIVE = "generation"
+END FOR
+
+FOR ALL Lambda WHERE Lambda.name = "Async" DO
+  ASSERT Lambda.environment.SPRING_PROFILES_ACTIVE = "core,async"
+END FOR
+```
+
+### Property Specification — Preservation Checking
+
+```pascal
+// Property: Preservation Checking — Non-buggy behavior unchanged
+FOR ALL X WHERE NOT isBugCondition(X) DO
+  ASSERT invoke(X) = invoke'(X)
+END FOR
+
+// Specifically: Async Lambda isolation preserved (profile unchanged at "core,async")
+FOR ALL X WHERE X.lambdaType = "async" DO
+  hooks ← activatedHooks'(X)
+  ASSERT "RuntimePrimingHook" ∉ hooks
+  ASSERT "GenerationPrimingHook" ∉ hooks
+  beans ← activatedBeans'(X)
+  ASSERT "MockNestConfig" ∉ beans
+END FOR
+```
+
+**Key Definitions:**
+- **F** (`invoke`): The original functions using `SPRING_PROFILES_ACTIVE: aws` with `@Profile("!async")` exclusions, without post-restore mapping reload
+- **F'** (`invoke'`): The fixed functions using capability-specific profiles (`runtime`, `generation`, `async`) with positive `@Profile` annotations, and CRaC `afterRestore` hook for mapping reload
+- **`activatedHooks(X)`**: The set of priming hooks that fire during Lambda initialization for invocation X under the old `aws` profile scheme
+- **`activatedHooks'(X)`**: The set of priming hooks that fire after the fix with capability-specific profiles (`@Profile("runtime")`, `@Profile("generation")`)
+- **`activatedBeans(X)`**: The set of Spring configuration beans loaded under the old `aws` profile scheme
+- **`activatedBeans'(X)`**: The set of Spring configuration beans loaded after the fix with capability-specific profiles

--- a/.kiro/specs/snapstart-mapping-reload/design.md
+++ b/.kiro/specs/snapstart-mapping-reload/design.md
@@ -1,0 +1,256 @@
+# SnapStart Mapping Reload & Profile Isolation Bugfix Design
+
+## Overview
+
+This design addresses two related bugs in the MockNest Serverless Lambda architecture:
+
+1. **Stale mappings after SnapStart restore** — WireMock's in-memory stub store is captured at snapshot time and never refreshed after restore. A CRaC `afterRestore` hook scoped to `@Profile("runtime")` will call `wireMockServer.resetMappings()`, which triggers `ObjectStorageMappingsSource.loadMappingsInto()` to reload all mappings from S3.
+
+2. **Priming hook cross-contamination** — The generic `aws` profile combined with `@Profile("!async")` negation causes both `RuntimePrimingHook` and `GenerationPrimingHook` to fire on both the Runtime and Generation Lambdas. `MockNestConfig` (WireMock server wiring) also loads on the Generation Lambda where it is not needed. The fix replaces `@Profile("!async")` with positive capability-specific profiles (`@Profile("runtime")`, `@Profile("generation")`) and updates the SAM template to set `SPRING_PROFILES_ACTIVE` per Lambda.
+
+The fix is minimal and surgical: no business logic changes, no WireMock engine changes, no S3 persistence changes. Only profile annotations, one new CRaC hook class, and SAM template environment variables are modified.
+
+## Glossary
+
+- **Bug_Condition (C)**: Two conditions that trigger the bugs — (1) SnapStart restore on the Runtime Lambda without mapping reload, and (2) cross-contamination of priming hooks and config beans due to the generic `aws` profile with negation-based `@Profile("!async")` exclusions
+- **Property (P)**: (1) After SnapStart restore, WireMock's in-memory stub store matches S3 state. (2) Each Lambda activates only its own priming hook and configuration beans
+- **Preservation**: Existing behavior that must remain unchanged — normal cold start mapping loading, priming logic, S3 persistence, async Lambda isolation, WireMock admin API, mock request matching
+- **`ObjectStorageMappingsSource`**: The `MappingsSource` implementation in `software/application` that loads WireMock stub mappings from S3 via `ObjectStorageInterface`
+- **`RuntimePrimingHook`**: Component in `software/infra/aws/runtime` that warms up WireMock engine during SnapStart snapshot creation
+- **`GenerationPrimingHook`**: Component in `software/infra/aws/generation` that warms up Bedrock clients and AI components during SnapStart snapshot creation
+- **`MockNestConfig`**: Spring `@Configuration` in `software/application` that wires `WireMockServer`, `DirectCallHttpServer`, and related beans
+- **CRaC**: Coordinated Restore at Checkpoint — the Java API (`org.crac`) used by SnapStart for lifecycle hooks (`beforeCheckpoint`, `afterRestore`)
+- **`resetMappings()`**: `WireMockServer` method that clears in-memory stubs and reloads from the configured `MappingsSource`
+
+## Bug Details
+
+### Bug Condition
+
+The bug manifests in two scenarios:
+
+**Scenario 1 — Stale mappings:** When SnapStart restores a Runtime Lambda snapshot, the in-memory WireMock stub store contains stale data from snapshot time. No `afterRestore` hook exists to reload mappings from S3, so mock requests return 404 / "no matching stub" until a manual `/__admin/mappings/reset` call is made.
+
+**Scenario 2 — Cross-contamination:** When any Lambda starts with `SPRING_PROFILES_ACTIVE: aws` (inherited from SAM Globals), all beans annotated `@Profile("!async")` are activated — including `RuntimePrimingHook`, `GenerationPrimingHook`, `MockNestConfig`, `RuntimeLambdaHandler`, `AdminRequestUseCase`, and `ClientRequestUseCase`. This means the Generation Lambda loads WireMock server beans it doesn't need, and the Runtime Lambda loads Bedrock/AI beans it doesn't need.
+
+**Formal Specification:**
+```
+FUNCTION isBugCondition(input)
+  INPUT: input of type LambdaInvocation
+  OUTPUT: boolean
+
+  // Condition 1: SnapStart restore without mapping reload
+  LET staleMappings = input.isSnapStartRestore = true
+                      AND input.lambdaType = "runtime"
+                      AND NOT postRestoreReloadExecuted(input)
+
+  // Condition 2: Cross-contamination via generic "aws" profile
+  LET crossContamination =
+        (input.lambdaType = "runtime" AND "GenerationPrimingHook" IN activatedBeans(input))
+     OR (input.lambdaType = "generation" AND "RuntimePrimingHook" IN activatedBeans(input))
+     OR (input.lambdaType = "generation" AND "MockNestConfig" IN activatedBeans(input))
+
+  RETURN staleMappings OR crossContamination
+END FUNCTION
+```
+
+### Examples
+
+- **Stale mappings**: Runtime Lambda restores from SnapStart snapshot → user sends `GET /mocknest/api/orders` → WireMock returns "no matching stub" (404) because in-memory stubs are from snapshot time, even though the mapping exists in S3
+- **Cross-contamination (Runtime)**: Runtime Lambda starts with `aws` profile → `GenerationPrimingHook` fires → attempts to warm up `BedrockRuntimeClient`, `ModelConfiguration`, `OpenAPISpecificationParser`, `PromptBuilderService` — wasting snapshot creation time and increasing snapshot size
+- **Cross-contamination (Generation)**: Generation Lambda starts with `aws` profile → `RuntimePrimingHook` fires → attempts to inject `WireMockServer` and `DirectCallHttpServer` which may fail or waste resources → `MockNestConfig` loads and wires WireMock server beans unnecessarily
+- **Manual workaround works**: After SnapStart restore, calling `POST /__admin/mappings/reset` triggers `ObjectStorageMappingsSource.loadMappingsInto()` and all mappings become available — confirming the data is in S3 but not loaded into memory
+
+## Expected Behavior
+
+### Preservation Requirements
+
+**Unchanged Behaviors:**
+- Normal (non-SnapStart) cold start continues to load mappings from S3 during `server.start()` via `ObjectStorageMappingsSource.loadMappingsInto()` — this path is not modified
+- `RuntimePrimingHook.prime()` logic (health check warm-up, S3 client initialization, WireMock engine exercise with journal suppression) remains identical — only the `@Profile` annotation changes
+- `GenerationPrimingHook.prime()` logic (Bedrock client warm-up, specification parser exercise, prompt builder exercise, mock validator exercise, SOAP/WSDL and GraphQL component exercise) remains identical — only the `@Profile` annotation changes
+- WireMock admin API persistence to S3 via `ObjectStorageMappingsSource.save()` / `remove()` / `removeAll()` is not modified
+- Mock request matching via `DirectCallHttpServer.stubRequest()` is not modified
+- Async Lambda profile configuration (`SPRING_PROFILES_ACTIVE: "core,async"`) is not modified
+- `RuntimeAsyncPrimingHook` (`@Profile("async")`) is not modified
+- `S3Configuration` (`@Profile("!local")`) is not modified — this profile exclusion is orthogonal to capability profiles
+- `BedrockConfiguration` (no profile annotation) is not modified — it remains available to any profile that needs it
+
+**Scope:**
+All inputs that do NOT involve SnapStart restore on the Runtime Lambda or profile-based bean activation are completely unaffected by this fix. This includes:
+- Non-SnapStart Lambda invocations (regular cold starts and warm invocations)
+- Mock request matching and response serving
+- WireMock admin API operations (save, remove, reset, list mappings)
+- S3 persistence operations
+- Async Lambda webhook dispatch
+
+## Hypothesized Root Cause
+
+Based on the bug description and code analysis, the root causes are:
+
+1. **Missing CRaC `afterRestore` hook**: `RuntimePrimingHook` implements `ApplicationReadyEvent` listener for snapshot-time priming but has no CRaC `Resource` implementation with `afterRestore()` to reload mappings after SnapStart restore. The WireMock server's in-memory stub store is captured in the snapshot and never refreshed.
+
+2. **Generic `aws` profile with negation-based exclusions**: The SAM template `Globals` section sets `SPRING_PROFILES_ACTIVE: aws` for all Lambdas. All runtime-specific beans use `@Profile("!async")` — a negation that only excludes the async Lambda. Since the `aws` profile is not `async`, all `@Profile("!async")` beans activate on every Lambda that inherits the global profile (Runtime and Generation). The profile system lacks positive capability identification.
+
+3. **Seven classes affected by `@Profile("!async")`**: The following classes all use `@Profile("!async")` and will cross-contaminate:
+   - `RuntimePrimingHook` (infra/aws/runtime)
+   - `GenerationPrimingHook` (infra/aws/generation)
+   - `MockNestConfig` (application/runtime)
+   - `RuntimeLambdaHandler` (infra/aws/runtime)
+   - `AdminRequestUseCase` (application/runtime)
+   - `ClientRequestUseCase` (application/runtime)
+
+4. **SAM template only overrides for Async Lambda**: Only the Async Lambda explicitly sets `SPRING_PROFILES_ACTIVE: "core,async"`. The Runtime and Generation Lambdas inherit the global `aws` value, making them indistinguishable to Spring's profile system.
+
+## Correctness Properties
+
+Property 1: Bug Condition — Mappings Reloaded After SnapStart Restore
+
+_For any_ Runtime Lambda invocation where SnapStart restore has occurred, the fixed system SHALL execute a CRaC `afterRestore` hook that calls `wireMockServer.resetMappings()`, causing `ObjectStorageMappingsSource.loadMappingsInto()` to reload all mappings from S3 into WireMock's in-memory stub store, so that subsequent mock requests return correct responses.
+
+**Validates: Requirements 2.1, 2.2**
+
+Property 2: Bug Condition — Profile-Based Bean Isolation
+
+_For any_ Lambda invocation, the fixed system SHALL activate only the priming hook and configuration beans that correspond to the Lambda's capability-specific profile: `@Profile("runtime")` beans on the Runtime Lambda, `@Profile("generation")` beans on the Generation Lambda, and `@Profile("async")` beans on the Async Lambda — eliminating cross-contamination.
+
+**Validates: Requirements 2.4, 2.5, 2.6, 2.7, 2.11, 2.12, 2.13**
+
+Property 3: Preservation — Unchanged Behavior for Non-Bug Inputs
+
+_For any_ input where the bug condition does NOT hold (non-SnapStart invocations, mock request matching, S3 persistence, admin API operations, async Lambda dispatch), the fixed system SHALL produce exactly the same behavior as the original system, preserving all existing functionality including normal cold start mapping loading, priming logic, journal suppression, and WireMock engine behavior.
+
+**Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8**
+
+## Fix Implementation
+
+### Changes Required
+
+Assuming our root cause analysis is correct:
+
+**File**: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHook.kt`
+
+**Change 1 — Profile annotation**: Change `@Profile("!async")` to `@Profile("runtime")`.
+
+**File**: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt` (NEW)
+
+**Change 2 — New CRaC afterRestore hook**: Create a new `@Component` class annotated `@Profile("runtime")` that implements `org.crac.Resource`. In `afterRestore()`, call `wireMockServer.resetMappings()` to reload all mappings from S3. Register itself with `org.crac.Core.getGlobalContext().register(this)` in the constructor or `@PostConstruct`. The `beforeCheckpoint()` method is a no-op.
+
+**File**: `software/infra/aws/generation/src/main/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationPrimingHook.kt`
+
+**Change 3 — Profile annotation**: Change `@Profile("!async")` to `@Profile("generation")`.
+
+**File**: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/config/MockNestConfig.kt`
+
+**Change 4 — Profile annotation**: Change `@Profile("!async")` to `@Profile("runtime")`.
+
+**File**: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/RuntimeLambdaHandler.kt`
+
+**Change 5 — Profile annotation**: Change `@Profile("!async")` to `@Profile("runtime")`.
+
+**File**: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/AdminRequestUseCase.kt`
+
+**Change 6 — Profile annotation**: Change `@Profile("!async")` to `@Profile("runtime")`.
+
+**File**: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/ClientRequestUseCase.kt`
+
+**Change 7 — Profile annotation**: Change `@Profile("!async")` to `@Profile("runtime")`.
+
+**File**: `deployment/aws/sam/template.yaml`
+
+**Change 8 — SAM template profiles**: 
+- Remove `SPRING_PROFILES_ACTIVE: aws` from `Globals.Function.Environment.Variables`
+- Add `SPRING_PROFILES_ACTIVE: runtime` to both `MockNestRuntimeFunction` and `MockNestRuntimeFunctionIam` environment variables
+- Add `SPRING_PROFILES_ACTIVE: generation` to both `MockNestGenerationFunction` and `MockNestGenerationFunctionIam` environment variables
+- Async Lambda functions already set `SPRING_PROFILES_ACTIVE: "core,async"` — no change needed
+
+**File**: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/RuntimeAsyncSpringContextTest.kt`
+
+**Change 9 — Update test assertions**: Update assertion messages that reference `@Profile(!async)` to reference the new positive profile annotations. The `@ActiveProfiles("async")` test itself should continue to pass because the beans now use positive profiles (`runtime`, `generation`) that don't match `async`.
+
+## Testing Strategy
+
+### Validation Approach
+
+The testing strategy follows a two-phase approach: first, surface counterexamples that demonstrate the bug on unfixed code, then verify the fix works correctly and preserves existing behavior.
+
+### Exploratory Bug Condition Checking
+
+**Goal**: Surface counterexamples that demonstrate the bug BEFORE implementing the fix. Confirm or refute the root cause analysis. If we refute, we will need to re-hypothesize.
+
+**Test Plan**: Write Spring integration tests that boot the application context with specific profiles and assert bean presence/absence. Run these tests on the UNFIXED code to observe failures and understand the root cause.
+
+**Test Cases**:
+1. **Runtime Profile Cross-Contamination Test**: Boot with `@ActiveProfiles("runtime")` — on unfixed code, `GenerationPrimingHook` will be present because `@Profile("!async")` matches any non-async profile (will fail on unfixed code because the `runtime` profile doesn't exist yet and beans won't load at all)
+2. **Generation Profile Cross-Contamination Test**: Boot with `@ActiveProfiles("generation")` — on unfixed code, `RuntimePrimingHook` and `MockNestConfig` will be present because `@Profile("!async")` matches (will fail on unfixed code for the same reason)
+3. **Stale Mappings Test**: Unit test that creates a `RuntimeMappingReloadHook` and verifies `afterRestore()` calls `wireMockServer.resetMappings()` (will fail on unfixed code because the class doesn't exist)
+
+**Expected Counterexamples**:
+- On unfixed code with `aws` profile: both `RuntimePrimingHook` and `GenerationPrimingHook` are present in the same context
+- On unfixed code: no CRaC `afterRestore` hook exists, so `wireMockServer.resetMappings()` is never called after restore
+
+### Fix Checking
+
+**Goal**: Verify that for all inputs where the bug condition holds, the fixed function produces the expected behavior.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE isBugCondition(input) DO
+  result := fixedSystem(input)
+  IF input.isSnapStartRestore AND input.lambdaType = "runtime" THEN
+    ASSERT afterRestoreHookExecuted(result)
+    ASSERT wireMockStubStore(result).mappings = S3MappingsSource.loadAll()
+  END IF
+  IF input.lambdaType = "runtime" THEN
+    ASSERT "RuntimePrimingHook" IN activatedBeans(result)
+    ASSERT "GenerationPrimingHook" NOT IN activatedBeans(result)
+  END IF
+  IF input.lambdaType = "generation" THEN
+    ASSERT "GenerationPrimingHook" IN activatedBeans(result)
+    ASSERT "RuntimePrimingHook" NOT IN activatedBeans(result)
+    ASSERT "MockNestConfig" NOT IN activatedBeans(result)
+  END IF
+END FOR
+```
+
+### Preservation Checking
+
+**Goal**: Verify that for all inputs where the bug condition does NOT hold, the fixed function produces the same result as the original function.
+
+**Pseudocode:**
+```
+FOR ALL input WHERE NOT isBugCondition(input) DO
+  ASSERT originalSystem(input) = fixedSystem(input)
+END FOR
+```
+
+**Testing Approach**: Property-based testing is recommended for preservation checking because:
+- It generates many test cases automatically across the input domain
+- It catches edge cases that manual unit tests might miss
+- It provides strong guarantees that behavior is unchanged for all non-buggy inputs
+
+**Test Plan**: Observe behavior on UNFIXED code first for non-bug inputs (async Lambda isolation, normal cold start mapping loading, WireMock admin API), then write tests capturing that behavior.
+
+**Test Cases**:
+1. **Async Lambda Isolation Preservation**: The existing `RuntimeAsyncSpringContextTest` with `@ActiveProfiles("async")` must continue to pass — verifying that async Lambda remains isolated from both runtime and generation components
+2. **Normal Cold Start Mapping Loading Preservation**: Verify that `MockNestConfig.wireMockServer()` still wires `ObjectStorageMappingsSource` as the `MappingsSource` and that `server.start()` triggers `loadMappingsInto()`
+3. **Priming Logic Preservation**: Verify that `RuntimePrimingHook.prime()` and `GenerationPrimingHook.prime()` method bodies are unchanged — only `@Profile` annotations change
+4. **WireMock Admin API Preservation**: Verify that `ObjectStorageMappingsSource.save()`, `remove()`, `removeAll()` continue to work
+
+### Unit Tests
+
+- Test `RuntimeMappingReloadHook.afterRestore()` calls `wireMockServer.resetMappings()` using MockK
+- Test `RuntimeMappingReloadHook.beforeCheckpoint()` is a no-op
+- Test `RuntimeMappingReloadHook` registers itself with CRaC global context
+
+### Property-Based Tests
+
+- `@SpringBootTest` with `@ActiveProfiles("runtime")` — assert runtime-specific beans present, generation-specific beans absent, post-restore hook present
+- `@SpringBootTest` with `@ActiveProfiles("generation")` — assert generation-specific beans present, runtime-specific beans absent, MockNestConfig absent
+- `@SpringBootTest` with `@ActiveProfiles("async")` — assert both runtime and generation beans absent (existing test, updated assertions)
+- Use `@ParameterizedTest` with bean name lists to verify presence/absence across profiles
+
+### Integration Tests
+
+- Full Spring context boot with `runtime` profile verifying WireMock server starts and serves mock responses
+- Full Spring context boot with `generation` profile verifying Bedrock client is available and WireMock is not loaded
+- SAM template validation (`sam validate`) confirming the template is syntactically correct after profile changes

--- a/.kiro/specs/snapstart-mapping-reload/tasks.md
+++ b/.kiro/specs/snapstart-mapping-reload/tasks.md
@@ -1,0 +1,198 @@
+# Implementation Plan
+
+- [x] 1. Write bug condition exploration test
+  - **Property 1: Bug Condition** — Profile Cross-Contamination & Missing Post-Restore Reload
+  - **CRITICAL**: This test MUST FAIL on unfixed code — failure confirms the bug exists
+  - **DO NOT attempt to fix the test or the code when it fails**
+  - **NOTE**: This test encodes the expected behavior — it will validate the fix when it passes after implementation
+  - **GOAL**: Surface counterexamples that demonstrate both bugs exist
+  - **Scoped PBT Approach**: Use `@ParameterizedTest` with `@MethodSource` to test profile-based bean isolation across all three profiles (`runtime`, `generation`, `async`)
+  - Write a `@SpringBootTest` with `@ActiveProfiles("runtime")` that asserts:
+    - `RuntimePrimingHook` IS present in the context
+    - `GenerationPrimingHook` is NOT present in the context
+    - `MockNestConfig` IS present in the context
+    - `RuntimeLambdaHandler` IS present in the context
+    - `AdminRequestUseCase` IS present in the context
+    - `ClientRequestUseCase` IS present in the context
+  - Write a `@SpringBootTest` with `@ActiveProfiles("generation")` that asserts:
+    - `GenerationPrimingHook` IS present in the context
+    - `RuntimePrimingHook` is NOT present in the context
+    - `MockNestConfig` is NOT present in the context
+    - `RuntimeLambdaHandler` is NOT present in the context
+  - Write a unit test that verifies `RuntimeMappingReloadHook` exists and its `afterRestore()` calls `wireMockServer.resetMappings()` — this will fail because the class does not exist yet
+  - Use `@ParameterizedTest` with bean name lists to verify presence/absence across profiles for stronger property coverage
+  - Run tests on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests FAIL (this is correct — it proves the bugs exist: `runtime` profile doesn't activate the right beans because `@Profile("!async")` is used, and `RuntimeMappingReloadHook` doesn't exist)
+  - Document counterexamples found to understand root cause
+  - Mark task complete when tests are written, run, and failure is documented
+  - _Requirements: 1.1, 1.2, 1.4, 1.5, 1.6, 1.7, 1.8, 2.1, 2.2, 2.4, 2.5, 2.6, 2.7, 2.11, 2.12, 2.13_
+
+- [x] 2. Write preservation property tests (BEFORE implementing fix)
+  - **Property 2: Preservation** — Async Lambda Isolation & Existing Behavior Unchanged
+  - **IMPORTANT**: Follow observation-first methodology
+  - Observe: `RuntimeAsyncSpringContextTest` with `@ActiveProfiles("async")` already passes — `wireMockServer`, `runtimePrimingHook`, `adminRequestUseCase`, `clientRequestUseCase`, `runtimeLambdaHandler` are all absent
+  - Observe: `MockNestConfig.wireMockServer()` wires `ObjectStorageMappingsSource` as the `MappingsSource` and `server.start()` triggers `loadMappingsInto()` — this is the normal cold start path
+  - Observe: `RuntimePrimingHook.prime()` exercises WireMock engine with journal suppression — method body is unchanged
+  - Write preservation property tests using `@ParameterizedTest`:
+    - **Async profile isolation**: Verify that `@ActiveProfiles("async")` context does NOT contain `runtimePrimingHook`, `generationPrimingHook`, `mockNestConfig`, `runtimeLambdaHandler`, `adminRequestUseCase`, `clientRequestUseCase` — parameterized over bean names
+    - **MockNestConfig wiring preservation**: Verify `MockNestConfig.wireMockServer()` still creates a running `WireMockServer` with `ObjectStorageMappingsSource`, extensions registered (NormalizeMappingBodyFilter, DeleteAllMappingsAndFilesFilter, RedactSensitiveHeadersFilter, WebhookAsyncEventPublisher)
+    - **RuntimePrimingHook priming logic preservation**: Verify `RuntimePrimingHook.prime()` still exercises WireMock engine (create stub, send request, remove stub) with journal suppression using MockK
+  - Verify tests PASS on UNFIXED code
+  - **EXPECTED OUTCOME**: Tests PASS (this confirms baseline behavior to preserve)
+  - Mark task complete when tests are written, run, and passing on unfixed code
+  - _Requirements: 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8_
+
+- [x] 3. Fix for SnapStart mapping reload & profile isolation
+
+  - [x] 3.1 Change `RuntimePrimingHook` profile annotation from `@Profile("!async")` to `@Profile("runtime")`
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHook.kt`
+    - Single-line change: `@Profile("!async")` → `@Profile("runtime")`
+    - _Bug_Condition: isBugCondition(input) where input.lambdaType = "runtime" AND "GenerationPrimingHook" IN activatedBeans(input) due to @Profile("!async")_
+    - _Expected_Behavior: activatedHooks'(X) contains "RuntimePrimingHook" only when X.profile = "runtime"_
+    - _Preservation: RuntimePrimingHook.prime() method body is unchanged — only annotation changes_
+    - _Requirements: 2.4, 2.5, 3.8_
+
+  - [x] 3.2 Create `RuntimeMappingReloadHook` CRaC class with `@Profile("runtime")`
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt` (NEW)
+    - Create a `@Component` class annotated `@Profile("runtime")` that implements `org.crac.Resource`
+    - Constructor-inject `WireMockServer` as `private val wireMockServer`
+    - In `@PostConstruct` (or init block), register with `org.crac.Core.getGlobalContext().register(this)`
+    - `afterRestore()`: call `wireMockServer.resetMappings()` to reload all mappings from S3 via `ObjectStorageMappingsSource.loadMappingsInto()`
+    - `beforeCheckpoint()`: no-op
+    - Use KotlinLogging for structured logging in `afterRestore()`
+    - _Bug_Condition: isBugCondition(input) where input.isSnapStartRestore = true AND NOT postRestoreReloadExecuted(input)_
+    - _Expected_Behavior: afterRestoreHookExecuted(result) = true AND wireMockStubStore(result).mappings = S3MappingsSource.loadAll()_
+    - _Preservation: Normal cold start mapping loading via server.start() is not modified_
+    - _Requirements: 2.1, 2.2, 2.6_
+
+  - [x] 3.3 Change `GenerationPrimingHook` profile annotation from `@Profile("!async")` to `@Profile("generation")`
+    - File: `software/infra/aws/generation/src/main/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationPrimingHook.kt`
+    - Single-line change: `@Profile("!async")` → `@Profile("generation")`
+    - _Bug_Condition: isBugCondition(input) where input.lambdaType = "generation" AND "RuntimePrimingHook" IN activatedBeans(input) due to @Profile("!async")_
+    - _Expected_Behavior: activatedHooks'(X) contains "GenerationPrimingHook" only when X.profile = "generation"_
+    - _Preservation: GenerationPrimingHook.prime() method body is unchanged — only annotation changes_
+    - _Requirements: 2.5, 3.7_
+
+  - [x] 3.4 Change `MockNestConfig` profile annotation from `@Profile("!async")` to `@Profile("runtime")`
+    - File: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/config/MockNestConfig.kt`
+    - Single-line change: `@Profile("!async")` → `@Profile("runtime")`
+    - _Bug_Condition: isBugCondition(input) where input.lambdaType = "generation" AND "MockNestConfig" IN activatedBeans(input)_
+    - _Expected_Behavior: "MockNestConfig" IN activatedBeans'(X) only when X.profile = "runtime"_
+    - _Preservation: MockNestConfig bean wiring logic is unchanged — only annotation changes_
+    - _Requirements: 2.7, 2.11_
+
+  - [x] 3.5 Change `RuntimeLambdaHandler` profile annotation from `@Profile("!async")` to `@Profile("runtime")`
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/RuntimeLambdaHandler.kt`
+    - Single-line change: `@Profile("!async")` → `@Profile("runtime")`
+    - _Bug_Condition: isBugCondition(input) where RuntimeLambdaHandler loads on generation Lambda due to @Profile("!async")_
+    - _Expected_Behavior: RuntimeLambdaHandler only loads when profile = "runtime"_
+    - _Preservation: RuntimeLambdaHandler routing logic is unchanged — only annotation changes_
+    - _Requirements: 2.4, 2.11_
+
+  - [x] 3.6 Change `AdminRequestUseCase` profile annotation from `@Profile("!async")` to `@Profile("runtime")`
+    - File: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/AdminRequestUseCase.kt`
+    - Single-line change: `@Profile("!async")` → `@Profile("runtime")`
+    - _Bug_Condition: isBugCondition(input) where AdminRequestUseCase loads on generation Lambda due to @Profile("!async")_
+    - _Expected_Behavior: AdminRequestUseCase only loads when profile = "runtime"_
+    - _Preservation: AdminRequestUseCase invoke logic is unchanged — only annotation changes_
+    - _Requirements: 2.4, 2.11_
+
+  - [x] 3.7 Change `ClientRequestUseCase` profile annotation from `@Profile("!async")` to `@Profile("runtime")`
+    - File: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/ClientRequestUseCase.kt`
+    - Single-line change: `@Profile("!async")` → `@Profile("runtime")`
+    - _Bug_Condition: isBugCondition(input) where ClientRequestUseCase loads on generation Lambda due to @Profile("!async")_
+    - _Expected_Behavior: ClientRequestUseCase only loads when profile = "runtime"_
+    - _Preservation: ClientRequestUseCase invoke logic is unchanged — only annotation changes_
+    - _Requirements: 2.4, 2.11_
+
+  - [x] 3.8 Update SAM template: remove global `SPRING_PROFILES_ACTIVE` and set per-Lambda profiles
+    - File: `deployment/aws/sam/template.yaml`
+    - Remove `SPRING_PROFILES_ACTIVE: aws` from `Globals.Function.Environment.Variables`
+    - Add `SPRING_PROFILES_ACTIVE: runtime` to `MockNestRuntimeFunction` Environment Variables
+    - Add `SPRING_PROFILES_ACTIVE: runtime` to `MockNestRuntimeFunctionIam` Environment Variables
+    - Add `SPRING_PROFILES_ACTIVE: generation` to `MockNestGenerationFunction` Environment Variables
+    - Add `SPRING_PROFILES_ACTIVE: generation` to `MockNestGenerationFunctionIam` Environment Variables
+    - Async Lambda functions (`MockNestRuntimeAsyncFunction`, `MockNestRuntimeAsyncFunctionIam`) already set `SPRING_PROFILES_ACTIVE: "core,async"` — no change needed
+    - Run `sam validate --template-file deployment/aws/sam/template.yaml --region eu-west-1` and confirm exit code 0
+    - _Bug_Condition: isBugCondition(input) where all Lambdas inherit SPRING_PROFILES_ACTIVE: aws from Globals_
+    - _Expected_Behavior: Runtime Lambda profile = "runtime", Generation Lambda profile = "generation", Async Lambda profile = "core,async"_
+    - _Preservation: Async Lambda SPRING_PROFILES_ACTIVE: "core,async" is unchanged_
+    - _Requirements: 2.8, 2.9, 2.10, 3.6_
+
+  - [x] 3.9 Update test assertions referencing `@Profile(!async)` in `RuntimeAsyncSpringContextTest`
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/RuntimeAsyncSpringContextTest.kt`
+    - Update assertion messages that reference `@Profile(!async)` to reference the new positive profile annotations (`@Profile("runtime")`, `@Profile("generation")`)
+    - The `@ActiveProfiles("async")` test itself should continue to pass because beans now use positive profiles that don't match `async`
+    - _Preservation: Test behavior is unchanged — only assertion message strings are updated_
+    - _Requirements: 2.13_
+
+  - [x] 3.10 Write unit tests for `RuntimeMappingReloadHook`
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt` (NEW)
+    - Follow Given-When-Then naming convention
+    - Use MockK with `relaxed = true` for `WireMockServer`
+    - Test `afterRestore()` calls `wireMockServer.resetMappings()` exactly once
+    - Test `beforeCheckpoint()` is a no-op (does not call any methods on `wireMockServer`)
+    - Test constructor registers with CRaC global context (verify `org.crac.Core.getGlobalContext().register()` is called)
+    - Include `@AfterEach` with `clearAllMocks()`
+    - _Requirements: 2.1, 2.2_
+
+  - [x] 3.11 Run `./gradlew clean test` and confirm all tests pass
+    - This checkpoint verifies the full build passes after all implementation changes
+    - All existing tests must continue to pass (preservation)
+    - New unit tests for `RuntimeMappingReloadHook` must pass
+
+  - [x] 3.12 Verify bug condition exploration test now passes
+    - **Property 1: Expected Behavior** — Profile Isolation & Post-Restore Reload Verified
+    - **IMPORTANT**: Re-run the SAME tests from task 1 — do NOT write new tests
+    - The tests from task 1 encode the expected behavior
+    - When these tests pass, it confirms:
+      - `@ActiveProfiles("runtime")` context contains only runtime beans (RuntimePrimingHook, MockNestConfig, RuntimeLambdaHandler, AdminRequestUseCase, ClientRequestUseCase) and NOT generation beans
+      - `@ActiveProfiles("generation")` context contains only generation beans (GenerationPrimingHook) and NOT runtime beans
+      - `RuntimeMappingReloadHook.afterRestore()` calls `wireMockServer.resetMappings()`
+    - Run bug condition exploration tests from task 1
+    - **EXPECTED OUTCOME**: Tests PASS (confirms bugs are fixed)
+    - _Requirements: 2.1, 2.2, 2.4, 2.5, 2.6, 2.7, 2.11, 2.12, 2.13_
+
+  - [x] 3.13 Verify preservation tests still pass
+    - **Property 2: Preservation** — Async Lambda Isolation & Existing Behavior Unchanged
+    - **IMPORTANT**: Re-run the SAME tests from task 2 — do NOT write new tests
+    - Run preservation property tests from task 2
+    - **EXPECTED OUTCOME**: Tests PASS (confirms no regressions)
+    - Confirm all preservation tests still pass after fix (no regressions)
+
+- [x] 4. Write Spring integration tests for profile-based bean wiring
+  - [x] 4.1 Write `@SpringBootTest` with `@ActiveProfiles("runtime")` integration test
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeProfileSpringContextTest.kt` (NEW)
+    - Boot full Spring context with `@ActiveProfiles("runtime")`
+    - Use `@ParameterizedTest` with `@MethodSource` for bean presence/absence checks:
+      - Beans that MUST be present: `runtimePrimingHook`, `mockNestConfig`, `wireMockServer`, `directCallHttpServer`, `runtimeLambdaHandler`, `adminRequestUseCase`, `clientRequestUseCase`, `runtimeMappingReloadHook`
+      - Beans that MUST be absent: `generationPrimingHook`
+    - Provide `TestConfiguration` with mock beans for S3, SQS dependencies (similar to `RuntimeAsyncSpringContextTest` pattern)
+    - Follow Given-When-Then naming convention
+    - _Requirements: 2.4, 2.11_
+
+  - [x] 4.2 Write `@SpringBootTest` with `@ActiveProfiles("generation")` integration test
+    - File: `software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationProfileSpringContextTest.kt` (NEW)
+    - Boot full Spring context with `@ActiveProfiles("generation")`
+    - Use `@ParameterizedTest` with `@MethodSource` for bean presence/absence checks:
+      - Beans that MUST be present: `generationPrimingHook`
+      - Beans that MUST be absent: `runtimePrimingHook`, `mockNestConfig`, `wireMockServer`, `directCallHttpServer`, `runtimeLambdaHandler`, `runtimeMappingReloadHook`
+    - Provide `TestConfiguration` with mock beans for Bedrock, S3 dependencies
+    - Follow Given-When-Then naming convention
+    - _Requirements: 2.5, 2.7, 2.12_
+
+  - [x] 4.3 Update existing `RuntimeAsyncSpringContextTest` assertions for `@ActiveProfiles("async")`
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/RuntimeAsyncSpringContextTest.kt`
+    - Add assertion that `generationPrimingHook` is absent (was not previously tested)
+    - Add assertion that `runtimeMappingReloadHook` is absent (new bean, must not load on async)
+    - Update assertion messages from `@Profile(!async)` to reference new positive profiles
+    - Existing assertions for `wireMockServer`, `runtimePrimingHook`, `adminRequestUseCase`, `clientRequestUseCase`, `runtimeLambdaHandler` absence remain unchanged
+    - _Requirements: 2.13_
+
+  - [x] 4.4 Run `./gradlew clean test` and confirm all tests pass
+    - This checkpoint verifies all Spring integration tests pass with the new profile configuration
+
+- [x] 5. Verify test coverage and quality
+  - [x] 5.1 Run `./gradlew koverHtmlReport` and verify 80%+ coverage for new code (enforced threshold; aim for 90%+ as a goal)
+  - [x] 5.2 Run `./gradlew koverVerify` to enforce coverage threshold
+  - [x] 5.3 Review test quality: Given-When-Then naming, proper assertions, edge case coverage

--- a/deployment/aws/sam/template.yaml
+++ b/deployment/aws/sam/template.yaml
@@ -269,9 +269,6 @@ Globals:
     Runtime: java25
     Architectures:
       - arm64
-    Environment:
-      Variables:
-        SPRING_PROFILES_ACTIVE: aws
 
 Resources:
   # S3 bucket for mock definitions and response payloads
@@ -555,6 +552,7 @@ Resources:
         ApplyOn: PublishedVersions
       Environment:
         Variables:
+          SPRING_PROFILES_ACTIVE: runtime
           MOCK_STORAGE_BUCKET: !Ref MockStorage
           MOCKNEST_S3_BUCKET_NAME: !Ref MockStorage
           SPRING_CLOUD_FUNCTION_DEFINITION: "runtimeRouter"
@@ -599,6 +597,7 @@ Resources:
         ApplyOn: PublishedVersions
       Environment:
         Variables:
+          SPRING_PROFILES_ACTIVE: runtime
           MOCK_STORAGE_BUCKET: !Ref MockStorage
           MOCKNEST_S3_BUCKET_NAME: !Ref MockStorage
           SPRING_CLOUD_FUNCTION_DEFINITION: "runtimeRouter"
@@ -643,6 +642,7 @@ Resources:
         ApplyOn: PublishedVersions
       Environment:
         Variables:
+          SPRING_PROFILES_ACTIVE: generation
           MOCK_STORAGE_BUCKET: !Ref MockStorage
           MOCKNEST_S3_BUCKET_NAME: !Ref MockStorage
           SPRING_CLOUD_FUNCTION_DEFINITION: "generationRouter"
@@ -681,6 +681,7 @@ Resources:
         ApplyOn: PublishedVersions
       Environment:
         Variables:
+          SPRING_PROFILES_ACTIVE: generation
           MOCK_STORAGE_BUCKET: !Ref MockStorage
           MOCKNEST_S3_BUCKET_NAME: !Ref MockStorage
           SPRING_CLOUD_FUNCTION_DEFINITION: "generationRouter"

--- a/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/config/MockNestConfig.kt
+++ b/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/config/MockNestConfig.kt
@@ -28,7 +28,7 @@ import org.springframework.context.annotation.PropertySource
 private val logger = KotlinLogging.logger {}
 
 @Configuration
-@Profile("!async")
+@Profile("runtime")
 @PropertySource("classpath:application.properties")
 class MockNestConfig {
 

--- a/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/AdminRequestUseCase.kt
+++ b/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/AdminRequestUseCase.kt
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component
 private val logger = KotlinLogging.logger {}
 
 @Component
-@Profile("!async")
+@Profile("runtime")
 class AdminRequestUseCase(
     private val directCallHttpServer: DirectCallHttpServer,
 ) : HandleAdminRequest {

--- a/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/ClientRequestUseCase.kt
+++ b/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/usecases/ClientRequestUseCase.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Component
-@Profile("!async")
+@Profile("runtime")
 class ClientRequestUseCase(private val directCallHttpServer: DirectCallHttpServer) :
     HandleClientRequest {
     override fun invoke(httpRequest: HttpRequest): HttpResponse {

--- a/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/PreservationPropertyTest.kt
+++ b/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/PreservationPropertyTest.kt
@@ -1,5 +1,6 @@
 package nl.vintik.mocknest.application.runtime.extensions
 
+import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.post
 import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
@@ -328,6 +329,72 @@ class PreservationPropertyTest {
         }
     }
 
+    // ── MockNestConfig wiring preservation — ObjectStorageMappingsSource & extensions ──
+
+    /**
+     * Preservation: MockNestConfig.wireMockServer() MUST continue to create a running
+     * WireMockServer with ObjectStorageMappingsSource as the MappingsSource and all four
+     * extensions registered: NormalizeMappingBodyFilter, DeleteAllMappingsAndFilesFilter,
+     * RedactSensitiveHeadersFilter, WebhookAsyncEventPublisher.
+     *
+     * This test parameterizes over extension names to verify each is registered.
+     *
+     * **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.7, 3.8**
+     */
+    @Nested
+    inner class MockNestConfigWiringPreservation {
+
+        private val mockStorage: ObjectStorageInterface = mockk(relaxed = true)
+        private val config = MockNestConfig()
+
+        private fun createServer(): WireMockServer {
+            val noopSqsPublisher = object : SqsPublisherInterface {
+                override suspend fun publish(queueUrl: String, messageBody: String) {}
+            }
+            val factory = config.directCallHttpServerFactory()
+            val redactFilter = config.redactSensitiveHeadersFilter(webhookConfig)
+            val journalStore = config.s3RequestJournalStore(mockStorage, webhookConfig, redactFilter)
+            return config.wireMockServer(
+                factory,
+                mockStorage,
+                webhookConfig,
+                noopSqsPublisher,
+                "https://sqs.eu-west-1.amazonaws.com/123/test-queue",
+                journalStore,
+                redactFilter,
+            )
+        }
+
+        @Test
+        fun `Given MockNestConfig When wireMockServer created Then server is running with ObjectStorageMappingsSource`() {
+            val server = createServer()
+            try {
+                assertTrue(server.isRunning, "Preservation: WireMock server must be running after creation")
+            } finally {
+                server.stop()
+            }
+        }
+
+        @ParameterizedTest(name = "Given MockNestConfig When wireMockServer created Then extension ''{0}'' is registered")
+        @MethodSource("nl.vintik.mocknest.application.runtime.extensions.PreservationPropertyTest#expectedExtensionNames")
+        fun `Given MockNestConfig When wireMockServer created Then expected extension is registered`(
+            extensionName: String,
+        ) {
+            val server = createServer()
+            try {
+                // WireMock registers extensions during configuration. If any extension
+                // fails to register, server.start() would throw. The server being running
+                // confirms all extensions were registered successfully.
+                assertTrue(server.isRunning,
+                    "Preservation: WireMock server must be running — confirms extension " +
+                        "'$extensionName' was registered without errors"
+                )
+            } finally {
+                server.stop()
+            }
+        }
+    }
+
     companion object {
         @JvmStatic
         fun validWebhookUrls() = listOf(
@@ -379,6 +446,14 @@ class PreservationPropertyTest {
                 sensitiveValue = "Bearer mixed-token",
                 json = """{"headers":{"Authorization":"Bearer mixed-token"}}""",
             ),
+        )
+
+        @JvmStatic
+        fun expectedExtensionNames() = listOf(
+            "normalize-mapping-body-filter",
+            "delete-all-mapping-and-files-filter",
+            "redact-sensitive-headers-filter",
+            "webhook",
         )
     }
 }

--- a/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/PreservationPropertyTest.kt
+++ b/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/PreservationPropertyTest.kt
@@ -382,12 +382,12 @@ class PreservationPropertyTest {
         ) {
             val server = createServer()
             try {
-                // WireMock registers extensions during configuration. If any extension
-                // fails to register, server.start() would throw. The server being running
-                // confirms all extensions were registered successfully.
-                assertTrue(server.isRunning,
-                    "Preservation: WireMock server must be running — confirms extension " +
-                        "'$extensionName' was registered without errors"
+                assertTrue(server.isRunning, "Server must be running before checking extensions")
+                val registeredExtensions = server.options.getDeclaredExtensions().instances
+                assertTrue(
+                    registeredExtensions.containsKey(extensionName),
+                    "Preservation: extension '$extensionName' must be registered in WireMockServer. " +
+                        "Registered: ${registeredExtensions.keys}"
                 )
             } finally {
                 server.stop()

--- a/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/PreservationPropertyTest.kt
+++ b/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/PreservationPropertyTest.kt
@@ -366,7 +366,7 @@ class PreservationPropertyTest {
         }
 
         @Test
-        fun `Given MockNestConfig When wireMockServer created Then server is running with ObjectStorageMappingsSource`() {
+        fun `Given MockNestConfig When wireMockServer created Then server is running`() {
             val server = createServer()
             try {
                 assertTrue(server.isRunning, "Preservation: WireMock server must be running after creation")

--- a/software/infra/aws/generation/src/main/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationPrimingHook.kt
+++ b/software/infra/aws/generation/src/main/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationPrimingHook.kt
@@ -37,7 +37,7 @@ private val logger = KotlinLogging.logger {}
  * Excluded from the `async` profile — the async Lambda has its own lightweight priming.
  */
 @Component
-@Profile("!async")
+@Profile("generation")
 open class GenerationPrimingHook(
     private val aiHealthUseCase: GetAIHealth,
     private val s3Client: S3Client,

--- a/software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationProfileSpringContextTest.kt
+++ b/software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/GenerationProfileSpringContextTest.kt
@@ -1,0 +1,98 @@
+package nl.vintik.mocknest.infra.aws.generation.snapstart
+
+import aws.sdk.kotlin.services.bedrockruntime.BedrockRuntimeClient
+import aws.sdk.kotlin.services.s3.S3Client
+import io.mockk.mockk
+import nl.vintik.mocknest.infra.aws.MockNestApplication
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Spring integration test for the `generation` profile.
+ *
+ * Verifies that booting the full Spring context with `@ActiveProfiles("generation")`
+ * activates exactly the generation-specific beans (GenerationPrimingHook, Bedrock/AI
+ * components) and does NOT activate runtime-specific beans (WireMock server, runtime
+ * priming hook, mapping reload hook, use cases).
+ *
+ * **Validates: Requirements 2.5, 2.7, 2.12**
+ */
+@SpringBootTest(
+    classes = [MockNestApplication::class, GenerationProfileSpringContextTest.TestConfig::class],
+    webEnvironment = NONE,
+    properties = ["spring.main.allow-bean-definition-overriding=true"],
+)
+@ActiveProfiles("generation")
+class GenerationProfileSpringContextTest {
+
+    /**
+     * Provides mock beans for AWS infrastructure dependencies that are not
+     * available in the test environment (S3, Bedrock).
+     */
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        @Primary
+        fun s3Client(): S3Client = mockk(relaxed = true)
+
+        @Bean
+        @Primary
+        fun bedrockRuntimeClient(): BedrockRuntimeClient = mockk(relaxed = true)
+    }
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @ParameterizedTest(name = "Bean ''{0}'' MUST be present in generation profile")
+    @MethodSource("generationExpectedPresentBeans")
+    fun `Given generation profile When context loads Then expected bean is present`(beanName: String) {
+        assertTrue(
+            applicationContext.containsBean(beanName),
+            "Bean '$beanName' must be present in @ActiveProfiles(\"generation\") context"
+        )
+    }
+
+    @ParameterizedTest(name = "Bean ''{0}'' MUST be absent in generation profile")
+    @MethodSource("generationExpectedAbsentBeans")
+    fun `Given generation profile When context loads Then runtime bean is absent`(beanName: String) {
+        assertFalse(
+            applicationContext.containsBean(beanName),
+            "Bean '$beanName' must be absent in @ActiveProfiles(\"generation\") context"
+        )
+    }
+
+    companion object {
+        /**
+         * Beans that MUST be present when @ActiveProfiles("generation") is active.
+         */
+        @JvmStatic
+        fun generationExpectedPresentBeans() = listOf(
+            "generationPrimingHook",
+        )
+
+        /**
+         * Beans that MUST be absent when @ActiveProfiles("generation") is active.
+         * Uses string bean names because runtime module classes are not on the
+         * generation module's classpath.
+         */
+        @JvmStatic
+        fun generationExpectedAbsentBeans() = listOf(
+            "runtimePrimingHook",
+            "mockNestConfig",
+            "wireMockServer",
+            "directCallHttpServer",
+            "runtimeLambdaHandler",
+            "runtimeMappingReloadHook",
+        )
+    }
+}

--- a/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/function/GraphQLMockingIntegrationTest.kt
+++ b/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/function/GraphQLMockingIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.TestInstance
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import java.util.function.Function
@@ -23,6 +24,7 @@ import kotlin.test.assertEquals
 @SpringBootTest(classes = [MockNestApplication::class])
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 @ContextConfiguration(classes = [AwsLocalStackTestConfiguration::class])
+@ActiveProfiles("runtime")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GraphQLMockingIntegrationTest {
 

--- a/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/function/RestApiMockingIntegrationTest.kt
+++ b/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/function/RestApiMockingIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestExecutionListeners
 import org.springframework.test.context.TestPropertySource
@@ -24,6 +25,7 @@ import kotlin.test.assertEquals
 @SpringBootTest(classes = [MockNestApplication::class])
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 @ContextConfiguration(classes = [AwsLocalStackTestConfiguration::class])
+@ActiveProfiles("runtime")
 @TestExecutionListeners(
     listeners = [
         TestContextDebugListener::class,

--- a/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/function/SoapMockingIntegrationTest.kt
+++ b/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/function/SoapMockingIntegrationTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.TestPropertySource
 import java.util.function.Function
@@ -21,6 +22,7 @@ import kotlin.test.assertEquals
 @SpringBootTest(classes = [MockNestApplication::class])
 @TestPropertySource(locations = ["classpath:application-test.properties"])
 @ContextConfiguration(classes = [AwsLocalStackTestConfiguration::class])
+@ActiveProfiles("runtime")
 class SoapMockingIntegrationTest {
 
     // Spring Boot will inject the lambda handler router

--- a/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/SnapStartPrimingIntegrationTest.kt
+++ b/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/snapstart/SnapStartPrimingIntegrationTest.kt
@@ -65,7 +65,7 @@ private val logger = KotlinLogging.logger {}
         "storage.bucket.name=$TEST_BUCKET_NAME"
     ]
 )
-@ActiveProfiles("test")
+@ActiveProfiles("test", "generation")
 @Import(AwsLocalStackTestConfiguration::class)
 @Testcontainers
 @Isolated

--- a/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/RuntimeLambdaHandlerIntegrationTest.kt
+++ b/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/RuntimeLambdaHandlerIntegrationTest.kt
@@ -38,7 +38,7 @@ private val logger = KotlinLogging.logger {}
         "storage.bucket.name=test-bucket"
     ]
 )
-@ActiveProfiles("test")
+@ActiveProfiles("test", "runtime")
 @Import(AwsLocalStackTestConfiguration::class)
 @Testcontainers
 class RuntimeLambdaHandlerIntegrationTest {

--- a/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/SnapStartBugConditionExplorationTest.kt
+++ b/software/infra/aws/mocknest/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/SnapStartBugConditionExplorationTest.kt
@@ -1,0 +1,191 @@
+package nl.vintik.mocknest.infra.aws.runtime.snapstart
+
+import aws.sdk.kotlin.services.bedrockruntime.BedrockRuntimeClient
+import aws.sdk.kotlin.services.s3.S3Client
+import io.mockk.mockk
+import nl.vintik.mocknest.application.core.interfaces.storage.ObjectStorageInterface
+import nl.vintik.mocknest.application.runtime.extensions.SqsPublisherInterface
+import nl.vintik.mocknest.infra.aws.MockNestApplication
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Bug Condition Exploration Tests — Property 1: Profile Cross-Contamination
+ *
+ * These tests PROVE the bugs exist on UNFIXED code.
+ * They are EXPECTED TO FAIL — that is the correct outcome, confirming the bug exists.
+ *
+ * DO NOT fix production code to make these pass.
+ * DO NOT fix these tests when they fail.
+ *
+ * Bug Condition (Cross-Contamination):
+ *   On unfixed code, all beans use @Profile("!async"). When booting with
+ *   @ActiveProfiles("runtime"), GenerationPrimingHook is also present because
+ *   "runtime" is not "async", so @Profile("!async") matches. Similarly, when
+ *   booting with @ActiveProfiles("generation"), RuntimePrimingHook, MockNestConfig,
+ *   RuntimeLambdaHandler, AdminRequestUseCase, and ClientRequestUseCase are all
+ *   present because "generation" is not "async".
+ *
+ * **Validates: Requirements 1.4, 1.5, 1.6, 1.7, 1.8, 2.4, 2.5, 2.7, 2.11, 2.12, 2.13**
+ */
+class SnapStartBugConditionExplorationTest {
+
+    /**
+     * Runtime profile context test — verifies bean isolation for the runtime Lambda.
+     *
+     * On FIXED code: RuntimePrimingHook, MockNestConfig, RuntimeLambdaHandler,
+     * AdminRequestUseCase, ClientRequestUseCase should be present, and
+     * GenerationPrimingHook should be absent.
+     *
+     * On UNFIXED code: GenerationPrimingHook will also be present (cross-contamination),
+     * causing the "absent" assertion to FAIL — proving the bug exists.
+     */
+    @Nested
+    @SpringBootTest(
+        classes = [MockNestApplication::class, SharedTestConfig::class],
+        webEnvironment = NONE,
+        properties = ["spring.main.allow-bean-definition-overriding=true"],
+    )
+    @ActiveProfiles("runtime")
+    inner class RuntimeProfileBeanIsolation {
+
+        @Autowired
+        private lateinit var applicationContext: ApplicationContext
+
+        @ParameterizedTest(name = "Bean ''{0}'' MUST be present in runtime profile")
+        @MethodSource("nl.vintik.mocknest.infra.aws.runtime.snapstart.SnapStartBugConditionExplorationTest#runtimeExpectedPresentBeans")
+        fun `Given runtime profile When context loads Then expected beans are present`(beanName: String) {
+            assertTrue(
+                applicationContext.containsBean(beanName),
+                "Bean '$beanName' must be present in @ActiveProfiles(\"runtime\") context"
+            )
+        }
+
+        @ParameterizedTest(name = "Bean ''{0}'' MUST be absent in runtime profile")
+        @MethodSource("nl.vintik.mocknest.infra.aws.runtime.snapstart.SnapStartBugConditionExplorationTest#runtimeExpectedAbsentBeans")
+        fun `Given runtime profile When context loads Then cross-contaminating beans are absent`(beanName: String) {
+            assertFalse(
+                applicationContext.containsBean(beanName),
+                "Bean '$beanName' must be absent in @ActiveProfiles(\"runtime\") context — " +
+                    "cross-contamination via @Profile(\"!async\")"
+            )
+        }
+    }
+
+    /**
+     * Generation profile context test — verifies bean isolation for the generation Lambda.
+     *
+     * On FIXED code: GenerationPrimingHook should be present, and RuntimePrimingHook,
+     * MockNestConfig, RuntimeLambdaHandler should be absent.
+     *
+     * On UNFIXED code: RuntimePrimingHook, MockNestConfig, RuntimeLambdaHandler will
+     * also be present (cross-contamination), causing the "absent" assertions to FAIL —
+     * proving the bug exists.
+     */
+    @Nested
+    @SpringBootTest(
+        classes = [MockNestApplication::class, SharedTestConfig::class],
+        webEnvironment = NONE,
+        properties = ["spring.main.allow-bean-definition-overriding=true"],
+    )
+    @ActiveProfiles("generation")
+    inner class GenerationProfileBeanIsolation {
+
+        @Autowired
+        private lateinit var applicationContext: ApplicationContext
+
+        @ParameterizedTest(name = "Bean ''{0}'' MUST be present in generation profile")
+        @MethodSource("nl.vintik.mocknest.infra.aws.runtime.snapstart.SnapStartBugConditionExplorationTest#generationExpectedPresentBeans")
+        fun `Given generation profile When context loads Then expected beans are present`(beanName: String) {
+            assertTrue(
+                applicationContext.containsBean(beanName),
+                "Bean '$beanName' must be present in @ActiveProfiles(\"generation\") context"
+            )
+        }
+
+        @ParameterizedTest(name = "Bean ''{0}'' MUST be absent in generation profile")
+        @MethodSource("nl.vintik.mocknest.infra.aws.runtime.snapstart.SnapStartBugConditionExplorationTest#generationExpectedAbsentBeans")
+        fun `Given generation profile When context loads Then runtime-only beans are absent`(beanName: String) {
+            assertFalse(
+                applicationContext.containsBean(beanName),
+                "Bean '$beanName' must be absent in @ActiveProfiles(\"generation\") context — " +
+                    "cross-contamination via @Profile(\"!async\")"
+            )
+        }
+    }
+
+    /**
+     * Shared TestConfiguration — provides mock beans for AWS infrastructure dependencies
+     * that are not available in the test environment (S3, SQS, Bedrock).
+     */
+    @TestConfiguration
+    class SharedTestConfig {
+        @Bean
+        @Primary
+        fun objectStorage(): ObjectStorageInterface = mockk(relaxed = true)
+
+        @Bean
+        fun sqsPublisher(): SqsPublisherInterface = mockk(relaxed = true)
+
+        @Bean
+        @Primary
+        fun s3Client(): S3Client = mockk(relaxed = true)
+
+        @Bean
+        @Primary
+        fun bedrockRuntimeClient(): BedrockRuntimeClient = mockk(relaxed = true)
+    }
+
+    companion object {
+        /**
+         * Beans that MUST be present when @ActiveProfiles("runtime") is active.
+         */
+        @JvmStatic
+        fun runtimeExpectedPresentBeans() = listOf(
+            "runtimePrimingHook",
+            "mockNestConfig",
+            "runtimeLambdaHandler",
+            "adminRequestUseCase",
+            "clientRequestUseCase",
+        )
+
+        /**
+         * Beans that MUST be absent when @ActiveProfiles("runtime") is active.
+         * On unfixed code, these will be present due to @Profile("!async") cross-contamination.
+         */
+        @JvmStatic
+        fun runtimeExpectedAbsentBeans() = listOf(
+            "generationPrimingHook",
+        )
+
+        /**
+         * Beans that MUST be present when @ActiveProfiles("generation") is active.
+         */
+        @JvmStatic
+        fun generationExpectedPresentBeans() = listOf(
+            "generationPrimingHook",
+        )
+
+        /**
+         * Beans that MUST be absent when @ActiveProfiles("generation") is active.
+         * On unfixed code, these will be present due to @Profile("!async") cross-contamination.
+         */
+        @JvmStatic
+        fun generationExpectedAbsentBeans() = listOf(
+            "runtimePrimingHook",
+            "mockNestConfig",
+            "runtimeLambdaHandler",
+        )
+    }
+}

--- a/software/infra/aws/runtime/build.gradle.kts
+++ b/software/infra/aws/runtime/build.gradle.kts
@@ -40,6 +40,9 @@ dependencies {
     implementation("com.amazonaws:aws-lambda-java-core")
     implementation("com.amazonaws:aws-lambda-java-events")
 
+    // CRaC API for SnapStart lifecycle hooks (beforeCheckpoint / afterRestore)
+    implementation("org.crac:crac:1.5.0")
+
     // Testing with LocalStack
     testImplementation("org.testcontainers:testcontainers")
     testImplementation("org.testcontainers:junit-jupiter")

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/RuntimeLambdaHandler.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/RuntimeLambdaHandler.kt
@@ -20,7 +20,7 @@ import java.util.function.Function
 private val logger = KotlinLogging.logger {}
 
 @Configuration
-@Profile("!async")
+@Profile("runtime")
 class RuntimeLambdaHandler(
     private val handleClientRequest: HandleClientRequest,
     private val handleAdminRequest: HandleAdminRequest,

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt
@@ -39,8 +39,12 @@ class RuntimeMappingReloadHook(
     }
 
     override fun afterRestore(context: Context<out Resource>?) {
-        logger.info { "SnapStart restore detected — reloading WireMock mappings from S3" }
-        wireMockServer.resetToDefaultMappings()
-        logger.info { "WireMock mappings reloaded successfully after SnapStart restore" }
+        runCatching {
+            logger.info { "SnapStart restore detected — reloading WireMock mappings from S3" }
+            wireMockServer.resetToDefaultMappings()
+            logger.info { "WireMock mappings reloaded successfully after SnapStart restore" }
+        }.onFailure { exception ->
+            logger.error(exception) { "SnapStart restore — failed to reload WireMock mappings from S3" }
+        }
     }
 }

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt
@@ -15,9 +15,13 @@ private val logger = KotlinLogging.logger {}
  * CRaC lifecycle hook that reloads WireMock mappings from S3 after SnapStart restore.
  *
  * When AWS Lambda restores a snapshot, the in-memory WireMock stub store contains
- * stale data from snapshot time. This hook calls [WireMockServer.resetMappings] in
- * [afterRestore], which triggers [ObjectStorageMappingsSource.loadMappingsInto] to
- * reload all mappings from S3 into WireMock's in-memory stub store.
+ * stale data from snapshot time. This hook calls [WireMockServer.resetToDefaultMappings]
+ * in [afterRestore], which clears the in-memory stub store and reloads all mappings
+ * from S3 via [ObjectStorageMappingsSource.loadMappingsInto].
+ *
+ * **Important**: We use [WireMockServer.resetToDefaultMappings] (not `resetMappings`).
+ * `resetMappings` calls `MappingsSaver.removeAll()` which deletes all mappings from S3.
+ * `resetToDefaultMappings` clears in-memory state and reloads from the MappingsSource.
  */
 @Component
 @Profile("runtime")
@@ -36,7 +40,7 @@ class RuntimeMappingReloadHook(
 
     override fun afterRestore(context: Context<out Resource>?) {
         logger.info { "SnapStart restore detected — reloading WireMock mappings from S3" }
-        wireMockServer.resetMappings()
+        wireMockServer.resetToDefaultMappings()
         logger.info { "WireMock mappings reloaded successfully after SnapStart restore" }
     }
 }

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHook.kt
@@ -1,0 +1,42 @@
+package nl.vintik.mocknest.infra.aws.runtime.snapstart
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.annotation.PostConstruct
+import org.crac.Context
+import org.crac.Core
+import org.crac.Resource
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+
+private val logger = KotlinLogging.logger {}
+
+/**
+ * CRaC lifecycle hook that reloads WireMock mappings from S3 after SnapStart restore.
+ *
+ * When AWS Lambda restores a snapshot, the in-memory WireMock stub store contains
+ * stale data from snapshot time. This hook calls [WireMockServer.resetMappings] in
+ * [afterRestore], which triggers [ObjectStorageMappingsSource.loadMappingsInto] to
+ * reload all mappings from S3 into WireMock's in-memory stub store.
+ */
+@Component
+@Profile("runtime")
+class RuntimeMappingReloadHook(
+    private val wireMockServer: WireMockServer
+) : Resource {
+
+    @PostConstruct
+    fun register() {
+        Core.getGlobalContext().register(this)
+    }
+
+    override fun beforeCheckpoint(context: Context<out Resource>?) {
+        // No-op: nothing to do before snapshot creation
+    }
+
+    override fun afterRestore(context: Context<out Resource>?) {
+        logger.info { "SnapStart restore detected — reloading WireMock mappings from S3" }
+        wireMockServer.resetMappings()
+        logger.info { "WireMock mappings reloaded successfully after SnapStart restore" }
+    }
+}

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHook.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHook.kt
@@ -37,7 +37,7 @@ private val logger = KotlinLogging.logger {}
  * - Uses graceful degradation for non-critical failures
  */
 @Component
-@Profile("!async")
+@Profile("runtime")
 class RuntimePrimingHook(
     private val healthCheckUseCase: GetRuntimeHealth,
     private val s3Client: S3Client,

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHook.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHook.kt
@@ -10,8 +10,8 @@ import com.github.tomakehurst.wiremock.http.RequestMethod
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
-import nl.vintik.mocknest.application.runtime.usecases.GetRuntimeHealth
 import nl.vintik.mocknest.application.runtime.journal.S3RequestJournalStore
+import nl.vintik.mocknest.application.runtime.usecases.GetRuntimeHealth
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.annotation.Profile
@@ -44,7 +44,7 @@ class RuntimePrimingHook(
     @param:Value($$"${storage.bucket.name}") private val bucketName: String,
     private val wireMockServer: WireMockServer,
     private val directCallHttpServer: DirectCallHttpServer,
-    private val journalStore: S3RequestJournalStore
+    private val journalStore: S3RequestJournalStore,
 ) {
 
     /**
@@ -147,7 +147,6 @@ class RuntimePrimingHook(
                     logger.debug { "Removed non-persistent test mapping: $testMappingId" }
                 }.onFailure { logger.warn(it) { "Failed to remove priming test mapping: $testMappingId" } }
         }
-
     }
 
     /**

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/AsyncProfileIsolationPreservationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/AsyncProfileIsolationPreservationTest.kt
@@ -63,6 +63,7 @@ class AsyncProfileIsolationPreservationTest {
             "runtimeLambdaHandler",
             "adminRequestUseCase",
             "clientRequestUseCase",
+            "runtimeMappingReloadHook",
         )
     }
 }

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/AsyncProfileIsolationPreservationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/AsyncProfileIsolationPreservationTest.kt
@@ -1,0 +1,68 @@
+package nl.vintik.mocknest.infra.aws.runtime.runtimeasync
+
+import nl.vintik.mocknest.application.runtime.extensions.SqsPublisherInterface
+import nl.vintik.mocknest.infra.aws.MockNestApplication
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertFalse
+
+/**
+ * Preservation Property Test — Async Profile Isolation
+ *
+ * Verifies that `@ActiveProfiles("async")` context does NOT contain runtime or generation
+ * beans. This MUST PASS on UNFIXED code to confirm the baseline behavior to preserve.
+ *
+ * Uses `@ParameterizedTest` with `@MethodSource` to check each bean name individually,
+ * providing clear failure messages per bean.
+ *
+ * **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.6, 3.7, 3.8**
+ */
+@SpringBootTest(
+    classes = [MockNestApplication::class, AsyncProfileIsolationPreservationTest.TestConfig::class],
+    webEnvironment = NONE,
+)
+@ActiveProfiles("async")
+class AsyncProfileIsolationPreservationTest {
+
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        fun sqsPublisher(): SqsPublisherInterface = object : SqsPublisherInterface {
+            override suspend fun publish(queueUrl: String, messageBody: String) {
+                // no-op — SQS publishing is not exercised in the async Lambda context
+            }
+        }
+    }
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @ParameterizedTest(name = "Given async profile When context loads Then bean ''{0}'' is absent")
+    @MethodSource("beansAbsentInAsyncProfile")
+    fun `Given async profile When context loads Then runtime and generation beans are absent`(beanName: String) {
+        assertFalse(
+            applicationContext.containsBean(beanName),
+            "Preservation: bean '$beanName' must be absent in async profile — " +
+                "async Lambda must remain isolated from runtime and generation components"
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        fun beansAbsentInAsyncProfile() = listOf(
+            "runtimePrimingHook",
+            "generationPrimingHook",
+            "mockNestConfig",
+            "runtimeLambdaHandler",
+            "adminRequestUseCase",
+            "clientRequestUseCase",
+        )
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/RuntimeAsyncSpringContextTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/runtimeasync/RuntimeAsyncSpringContextTest.kt
@@ -108,23 +108,31 @@ class RuntimeAsyncSpringContextTest {
     @Test
     fun `Given async profile active When Spring context loads Then wireMockServer bean is NOT registered by MockNestConfig`() {
         assertFalse(applicationContext.containsBean("wireMockServer"),
-            "wireMockServer must be absent — MockNestConfig excluded by @Profile(!async)")
+            "wireMockServer must be absent — MockNestConfig scoped to @Profile(\"runtime\")")
         assertFalse(applicationContext.containsBean("directCallHttpServerFactory"),
-            "directCallHttpServerFactory must be absent — MockNestConfig excluded by @Profile(!async)")
+            "directCallHttpServerFactory must be absent — MockNestConfig scoped to @Profile(\"runtime\")")
         assertFalse(applicationContext.containsBean("wiremockFilesBlobStore"),
-            "wiremockFilesBlobStore must be absent — MockNestConfig excluded by @Profile(!async)")
+            "wiremockFilesBlobStore must be absent — MockNestConfig scoped to @Profile(\"runtime\")")
     }
 
     @Test
     fun `Given async profile When context loads Then runtime request-handling beans are absent`() {
         assertFalse(applicationContext.containsBean("adminRequestUseCase"),
-            "adminRequestUseCase must be absent — excluded by @Profile(!async)")
+            "adminRequestUseCase must be absent — scoped to @Profile(\"runtime\")")
         assertFalse(applicationContext.containsBean("clientRequestUseCase"),
-            "clientRequestUseCase must be absent — excluded by @Profile(!async)")
+            "clientRequestUseCase must be absent — scoped to @Profile(\"runtime\")")
         assertFalse(applicationContext.containsBean("runtimeLambdaHandler"),
-            "runtimeLambdaHandler must be absent — excluded by @Profile(!async)")
+            "runtimeLambdaHandler must be absent — scoped to @Profile(\"runtime\")")
         assertFalse(applicationContext.containsBean("runtimePrimingHook"),
-            "runtimePrimingHook must be absent — excluded by @Profile(!async)")
+            "runtimePrimingHook must be absent — scoped to @Profile(\"runtime\")")
+        assertFalse(applicationContext.containsBean("runtimeMappingReloadHook"),
+            "runtimeMappingReloadHook must be absent — scoped to @Profile(\"runtime\")")
+    }
+
+    @Test
+    fun `Given async profile When context loads Then generationPrimingHook is absent`() {
+        assertFalse(applicationContext.containsBean("generationPrimingHook"),
+            "generationPrimingHook must be absent — scoped to @Profile(\"generation\")")
     }
 
     // ── End-to-end dispatch assertion ─────────────────────────────────────────

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookExplorationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookExplorationTest.kt
@@ -6,34 +6,30 @@ import kotlin.test.assertTrue
 /**
  * Bug Condition Exploration Test — Property 1: Missing Post-Restore Reload
  *
- * This test PROVES the bug exists on UNFIXED code by verifying that
- * RuntimeMappingReloadHook does not exist yet.
+ * On unfixed code, `Class.forName("...RuntimeMappingReloadHook")` throws
+ * `ClassNotFoundException` because the class does not exist yet — the test FAILS,
+ * proving the bug exists (no CRaC afterRestore hook to reload mappings).
  *
- * EXPECTED TO FAIL on unfixed code — the class does not exist, so the
- * Class.forName call will throw ClassNotFoundException.
- *
- * DO NOT fix production code to make this pass.
- * DO NOT fix this test when it fails.
+ * On fixed code, the class exists, implements `org.crac.Resource`, and declares
+ * an `afterRestore` method — the test PASSES, verifying the fix.
  *
  * **Validates: Requirements 2.1, 2.2, 2.6**
  */
 class RuntimeMappingReloadHookExplorationTest {
 
     @Test
-    fun `Given unfixed code When checking for RuntimeMappingReloadHook Then class exists`() {
-        // This will throw ClassNotFoundException on unfixed code because
-        // RuntimeMappingReloadHook has not been created yet — proving the bug exists.
+    fun `Given fixed code When checking for RuntimeMappingReloadHook Then class exists with afterRestore method`() {
         val clazz = Class.forName(
             "nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimeMappingReloadHook"
         )
         assertTrue(
             clazz.declaredMethods.any { it.name == "afterRestore" },
-            "RuntimeMappingReloadHook must have an afterRestore() method that calls wireMockServer.resetMappings()"
+            "RuntimeMappingReloadHook must have an afterRestore() method"
         )
     }
 
     @Test
-    fun `Given unfixed code When checking RuntimeMappingReloadHook Then it implements CRaC Resource`() {
+    fun `Given fixed code When checking RuntimeMappingReloadHook Then it implements CRaC Resource`() {
         val clazz = Class.forName(
             "nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimeMappingReloadHook"
         )

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookExplorationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookExplorationTest.kt
@@ -1,0 +1,46 @@
+package nl.vintik.mocknest.infra.aws.runtime.snapstart
+
+import org.junit.jupiter.api.Test
+import kotlin.test.assertTrue
+
+/**
+ * Bug Condition Exploration Test — Property 1: Missing Post-Restore Reload
+ *
+ * This test PROVES the bug exists on UNFIXED code by verifying that
+ * RuntimeMappingReloadHook does not exist yet.
+ *
+ * EXPECTED TO FAIL on unfixed code — the class does not exist, so the
+ * Class.forName call will throw ClassNotFoundException.
+ *
+ * DO NOT fix production code to make this pass.
+ * DO NOT fix this test when it fails.
+ *
+ * **Validates: Requirements 2.1, 2.2, 2.6**
+ */
+class RuntimeMappingReloadHookExplorationTest {
+
+    @Test
+    fun `Given unfixed code When checking for RuntimeMappingReloadHook Then class exists`() {
+        // This will throw ClassNotFoundException on unfixed code because
+        // RuntimeMappingReloadHook has not been created yet — proving the bug exists.
+        val clazz = Class.forName(
+            "nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimeMappingReloadHook"
+        )
+        assertTrue(
+            clazz.declaredMethods.any { it.name == "afterRestore" },
+            "RuntimeMappingReloadHook must have an afterRestore() method that calls wireMockServer.resetMappings()"
+        )
+    }
+
+    @Test
+    fun `Given unfixed code When checking RuntimeMappingReloadHook Then it implements CRaC Resource`() {
+        val clazz = Class.forName(
+            "nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimeMappingReloadHook"
+        )
+        val implementsCrac = clazz.interfaces.any { it.name == "org.crac.Resource" }
+        assertTrue(
+            implementsCrac,
+            "RuntimeMappingReloadHook must implement org.crac.Resource for SnapStart afterRestore lifecycle"
+        )
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import io.mockk.clearAllMocks
 import io.mockk.mockk
 import io.mockk.mockkStatic
+import io.mockk.unmockkAll
 import io.mockk.verify
 import org.crac.Context
 import org.crac.Core
@@ -26,6 +27,7 @@ class RuntimeMappingReloadHookTest {
     @AfterEach
     fun tearDown() {
         clearAllMocks()
+        unmockkAll()
     }
 
     @Test

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt
@@ -29,7 +29,7 @@ class RuntimeMappingReloadHookTest {
     }
 
     @Test
-    fun `Given a restored snapshot When afterRestore is called Then wireMockServer resetMappings is called exactly once`() {
+    fun `Given a restored snapshot When afterRestore is called Then wireMockServer resetToDefaultMappings is called exactly once`() {
         // Given
         val hook = createHookWithoutRegistration()
         val context: Context<out Resource> = mockk(relaxed = true)
@@ -38,7 +38,7 @@ class RuntimeMappingReloadHookTest {
         hook.afterRestore(context)
 
         // Then
-        verify(exactly = 1) { wireMockServer.resetMappings() }
+        verify(exactly = 1) { wireMockServer.resetToDefaultMappings() }
     }
 
     @Test
@@ -51,6 +51,7 @@ class RuntimeMappingReloadHookTest {
         hook.beforeCheckpoint(context)
 
         // Then
+        verify(exactly = 0) { wireMockServer.resetToDefaultMappings() }
         verify(exactly = 0) { wireMockServer.resetMappings() }
         verify(exactly = 0) { wireMockServer.stop() }
         verify(exactly = 0) { wireMockServer.start() }

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeMappingReloadHookTest.kt
@@ -1,0 +1,85 @@
+package nl.vintik.mocknest.infra.aws.runtime.snapstart
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import io.mockk.clearAllMocks
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.crac.Context
+import org.crac.Core
+import org.crac.Resource
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [RuntimeMappingReloadHook].
+ *
+ * Verifies CRaC lifecycle behavior: `afterRestore()` reloads WireMock mappings,
+ * `beforeCheckpoint()` is a no-op, and the hook registers with the CRaC global context.
+ *
+ * **Validates: Requirements 2.1, 2.2**
+ */
+class RuntimeMappingReloadHookTest {
+
+    private val wireMockServer: WireMockServer = mockk(relaxed = true)
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `Given a restored snapshot When afterRestore is called Then wireMockServer resetMappings is called exactly once`() {
+        // Given
+        val hook = createHookWithoutRegistration()
+        val context: Context<out Resource> = mockk(relaxed = true)
+
+        // When
+        hook.afterRestore(context)
+
+        // Then
+        verify(exactly = 1) { wireMockServer.resetMappings() }
+    }
+
+    @Test
+    fun `Given a checkpoint is about to be created When beforeCheckpoint is called Then no methods are called on wireMockServer`() {
+        // Given
+        val hook = createHookWithoutRegistration()
+        val context: Context<out Resource> = mockk(relaxed = true)
+
+        // When
+        hook.beforeCheckpoint(context)
+
+        // Then
+        verify(exactly = 0) { wireMockServer.resetMappings() }
+        verify(exactly = 0) { wireMockServer.stop() }
+        verify(exactly = 0) { wireMockServer.start() }
+        verify(exactly = 0) { wireMockServer.stubFor(any()) }
+    }
+
+    @Test
+    fun `Given a new RuntimeMappingReloadHook When register is called Then it registers with CRaC global context`() {
+        // Given
+        val mockContext: org.crac.Context<Resource> = mockk(relaxed = true)
+        mockkStatic(Core::class)
+        io.mockk.every { Core.getGlobalContext() } returns mockContext
+
+        // When
+        val hook = RuntimeMappingReloadHook(wireMockServer)
+        hook.register()
+
+        // Then
+        verify(exactly = 1) { mockContext.register(hook) }
+    }
+
+    /**
+     * Creates a [RuntimeMappingReloadHook] without triggering CRaC registration,
+     * so tests can focus on `afterRestore` and `beforeCheckpoint` behavior in isolation.
+     */
+    private fun createHookWithoutRegistration(): RuntimeMappingReloadHook {
+        val mockContext: org.crac.Context<Resource> = mockk(relaxed = true)
+        mockkStatic(Core::class)
+        io.mockk.every { Core.getGlobalContext() } returns mockContext
+        return RuntimeMappingReloadHook(wireMockServer)
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookPreservationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookPreservationTest.kt
@@ -29,9 +29,6 @@ import java.util.UUID
  * Verifies that `RuntimePrimingHook.prime()` still exercises the WireMock engine
  * (create stub, send request, remove stub) with journal suppression using MockK.
  *
- * These tests MUST PASS on UNFIXED code to confirm the baseline behavior to preserve.
- * The prime() method body is unchanged by the fix — only the @Profile annotation changes.
- *
  * **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.7, 3.8**
  */
 class RuntimePrimingHookPreservationTest {
@@ -56,8 +53,6 @@ class RuntimePrimingHookPreservationTest {
     fun tearDown() {
         clearAllMocks()
     }
-
-    // ── Preservation: WireMock engine exercise sequence ──────────────────────
 
     @Test
     fun `Given prime called When WireMock engine exercised Then stub is created before request is sent`() = runTest {
@@ -104,8 +99,6 @@ class RuntimePrimingHookPreservationTest {
         verify { mockJournalStore.suppressWrites() }
         verify { mockJournalStore.enableWrites() }
     }
-
-    // ── Preservation: Parameterized verification of all priming steps ────────
 
     @ParameterizedTest(name = "Given prime called When all steps succeed Then ''{0}'' is invoked")
     @MethodSource("primingStepVerifications")

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookPreservationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookPreservationTest.kt
@@ -65,9 +65,11 @@ class RuntimePrimingHookPreservationTest {
         primingHook.prime()
 
         // Then — verify the WireMock exercise sequence: create stub → send request → remove stub
-        verify { mockWireMockServer.stubFor(any()) }
-        verify { mockDirectCallHttpServer.stubRequest(any()) }
-        verify { mockWireMockServer.removeStubMapping(any<UUID>()) }
+        io.mockk.verifyOrder {
+            mockWireMockServer.stubFor(any())
+            mockDirectCallHttpServer.stubRequest(any())
+            mockWireMockServer.removeStubMapping(any<UUID>())
+        }
     }
 
     @Test

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookPreservationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookPreservationTest.kt
@@ -1,0 +1,154 @@
+package nl.vintik.mocknest.infra.aws.runtime.snapstart
+
+import aws.sdk.kotlin.services.s3.S3Client
+import aws.sdk.kotlin.services.s3.model.HeadBucketResponse
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.direct.DirectCallHttpServer
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import nl.vintik.mocknest.application.runtime.journal.S3RequestJournalStore
+import nl.vintik.mocknest.application.runtime.usecases.GetRuntimeHealth
+import nl.vintik.mocknest.domain.core.HttpResponse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.http.HttpStatus
+import java.util.UUID
+
+/**
+ * Preservation Property Test — RuntimePrimingHook Priming Logic
+ *
+ * Verifies that `RuntimePrimingHook.prime()` still exercises the WireMock engine
+ * (create stub, send request, remove stub) with journal suppression using MockK.
+ *
+ * These tests MUST PASS on UNFIXED code to confirm the baseline behavior to preserve.
+ * The prime() method body is unchanged by the fix — only the @Profile annotation changes.
+ *
+ * **Validates: Requirements 3.1, 3.2, 3.3, 3.4, 3.5, 3.7, 3.8**
+ */
+class RuntimePrimingHookPreservationTest {
+
+    private val mockHealthCheckUseCase: GetRuntimeHealth = mockk(relaxed = true)
+    private val mockS3Client: S3Client = mockk(relaxed = true)
+    private val testBucketName = "test-bucket"
+    private val mockWireMockServer: WireMockServer = mockk(relaxed = true)
+    private val mockDirectCallHttpServer: DirectCallHttpServer = mockk(relaxed = true)
+    private val mockJournalStore: S3RequestJournalStore = mockk(relaxed = true)
+
+    private val primingHook = RuntimePrimingHook(
+        mockHealthCheckUseCase,
+        mockS3Client,
+        testBucketName,
+        mockWireMockServer,
+        mockDirectCallHttpServer,
+        mockJournalStore,
+    )
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    // ── Preservation: WireMock engine exercise sequence ──────────────────────
+
+    @Test
+    fun `Given prime called When WireMock engine exercised Then stub is created before request is sent`() = runTest {
+        // Given
+        every { mockHealthCheckUseCase.invoke() } returns HttpResponse(HttpStatus.OK, body = "healthy")
+        coEvery { mockS3Client.headBucket(any()) } returns HeadBucketResponse { }
+        every { mockWireMockServer.removeStubMapping(any<UUID>()) } just Runs
+
+        // When
+        primingHook.prime()
+
+        // Then — verify the WireMock exercise sequence: create stub → send request → remove stub
+        verify { mockWireMockServer.stubFor(any()) }
+        verify { mockDirectCallHttpServer.stubRequest(any()) }
+        verify { mockWireMockServer.removeStubMapping(any<UUID>()) }
+    }
+
+    @Test
+    fun `Given prime called When WireMock engine exercised Then journal writes are suppressed during request`() = runTest {
+        // Given
+        every { mockHealthCheckUseCase.invoke() } returns HttpResponse(HttpStatus.OK, body = "healthy")
+        coEvery { mockS3Client.headBucket(any()) } returns HeadBucketResponse { }
+        every { mockWireMockServer.removeStubMapping(any<UUID>()) } just Runs
+
+        // When
+        primingHook.prime()
+
+        // Then — verify journal suppression: suppressWrites before request, enableWrites after
+        verify { mockJournalStore.suppressWrites() }
+        verify { mockJournalStore.enableWrites() }
+    }
+
+    @Test
+    fun `Given prime called When WireMock engine exercised Then journal writes are re-enabled even on failure`() = runTest {
+        // Given — stubRequest throws to simulate failure
+        every { mockHealthCheckUseCase.invoke() } returns HttpResponse(HttpStatus.OK, body = "healthy")
+        coEvery { mockS3Client.headBucket(any()) } returns HeadBucketResponse { }
+        every { mockDirectCallHttpServer.stubRequest(any()) } throws RuntimeException("Request failed")
+
+        // When — prime should not throw (graceful degradation)
+        primingHook.prime()
+
+        // Then — journal writes must be re-enabled even after failure
+        verify { mockJournalStore.suppressWrites() }
+        verify { mockJournalStore.enableWrites() }
+    }
+
+    // ── Preservation: Parameterized verification of all priming steps ────────
+
+    @ParameterizedTest(name = "Given prime called When all steps succeed Then ''{0}'' is invoked")
+    @MethodSource("primingStepVerifications")
+    fun `Given prime called When all steps succeed Then expected priming step is invoked`(
+        stepName: String,
+        verifier: (RuntimePrimingHookPreservationTest) -> Unit,
+    ) = runTest {
+        // Given — all steps succeed
+        every { mockHealthCheckUseCase.invoke() } returns HttpResponse(HttpStatus.OK, body = "healthy")
+        coEvery { mockS3Client.headBucket(any()) } returns HeadBucketResponse { }
+        every { mockWireMockServer.removeStubMapping(any<UUID>()) } just Runs
+
+        // When
+        primingHook.prime()
+
+        // Then
+        verifier(this@RuntimePrimingHookPreservationTest)
+    }
+
+    companion object {
+        @JvmStatic
+        fun primingStepVerifications() = listOf(
+            arrayOf("healthCheck.invoke()", { test: RuntimePrimingHookPreservationTest ->
+                verify { test.mockHealthCheckUseCase.invoke() }
+            }),
+            arrayOf("s3Client.headBucket()", { test: RuntimePrimingHookPreservationTest ->
+                coVerify { test.mockS3Client.headBucket(any()) }
+            }),
+            arrayOf("wireMockServer.stubFor()", { test: RuntimePrimingHookPreservationTest ->
+                verify { test.mockWireMockServer.stubFor(any()) }
+            }),
+            arrayOf("directCallHttpServer.stubRequest()", { test: RuntimePrimingHookPreservationTest ->
+                verify { test.mockDirectCallHttpServer.stubRequest(any()) }
+            }),
+            arrayOf("wireMockServer.removeStubMapping()", { test: RuntimePrimingHookPreservationTest ->
+                verify { test.mockWireMockServer.removeStubMapping(any<UUID>()) }
+            }),
+            arrayOf("journalStore.suppressWrites()", { test: RuntimePrimingHookPreservationTest ->
+                verify { test.mockJournalStore.suppressWrites() }
+            }),
+            arrayOf("journalStore.enableWrites()", { test: RuntimePrimingHookPreservationTest ->
+                verify { test.mockJournalStore.enableWrites() }
+            }),
+        )
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimePrimingHookTest.kt
@@ -4,10 +4,17 @@ import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.HeadBucketResponse
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.direct.DirectCallHttpServer
-import io.mockk.*
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
-import nl.vintik.mocknest.application.runtime.usecases.GetRuntimeHealth
 import nl.vintik.mocknest.application.runtime.journal.S3RequestJournalStore
+import nl.vintik.mocknest.application.runtime.usecases.GetRuntimeHealth
 import nl.vintik.mocknest.domain.core.HttpResponse
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Nested
@@ -21,7 +28,7 @@ import org.springframework.http.HttpStatus
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
 import uk.org.webcompere.systemstubs.jupiter.SystemStub
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension
-import java.util.*
+import java.util.UUID
 import java.util.stream.Stream
 
 @Isolated
@@ -43,7 +50,7 @@ class RuntimePrimingHookTest {
         testBucketName,
         mockWireMockServer,
         mockDirectCallHttpServer,
-        mockJournalStore
+        mockJournalStore,
     )
 
     @AfterEach
@@ -252,7 +259,7 @@ class RuntimePrimingHookTest {
         @MethodSource("nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimePrimingHookTest#snapStartInitTypes")
         fun `Given AWS_LAMBDA_INITIALIZATION_TYPE When onApplicationReady is called Then should invoke priming accordingly`(
             initType: String?,
-            shouldPrime: Boolean
+            shouldPrime: Boolean,
         ) {
             // Given
             environmentVariables.set(envVarName, initType)

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeProfileSpringContextTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/snapstart/RuntimeProfileSpringContextTest.kt
@@ -1,0 +1,105 @@
+package nl.vintik.mocknest.infra.aws.runtime.snapstart
+
+import aws.sdk.kotlin.services.s3.S3Client
+import io.mockk.mockk
+import nl.vintik.mocknest.application.core.interfaces.storage.ObjectStorageInterface
+import nl.vintik.mocknest.application.runtime.extensions.SqsPublisherInterface
+import nl.vintik.mocknest.infra.aws.MockNestApplication
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+import org.springframework.test.context.ActiveProfiles
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Spring integration test for the `runtime` profile.
+ *
+ * Verifies that booting the full Spring context with `@ActiveProfiles("runtime")`
+ * activates exactly the runtime-specific beans (WireMock server, priming hook,
+ * mapping reload hook, use cases) and does NOT activate generation-specific beans.
+ *
+ * **Validates: Requirements 2.4, 2.11**
+ */
+@SpringBootTest(
+    classes = [MockNestApplication::class, RuntimeProfileSpringContextTest.TestConfig::class],
+    webEnvironment = NONE,
+    properties = ["spring.main.allow-bean-definition-overriding=true"],
+)
+@ActiveProfiles("runtime")
+class RuntimeProfileSpringContextTest {
+
+    /**
+     * Provides mock beans for AWS infrastructure dependencies that are not
+     * available in the test environment (S3, SQS).
+     */
+    @TestConfiguration
+    class TestConfig {
+        @Bean
+        @Primary
+        fun objectStorage(): ObjectStorageInterface = mockk(relaxed = true)
+
+        @Bean
+        fun sqsPublisher(): SqsPublisherInterface = object : SqsPublisherInterface {
+            override suspend fun publish(queueUrl: String, messageBody: String) {
+                // no-op — SQS publishing is not exercised in this context test
+            }
+        }
+
+        @Bean
+        @Primary
+        fun s3Client(): S3Client = mockk(relaxed = true)
+    }
+
+    @Autowired
+    private lateinit var applicationContext: ApplicationContext
+
+    @ParameterizedTest(name = "Bean ''{0}'' MUST be present in runtime profile")
+    @MethodSource("runtimeExpectedPresentBeans")
+    fun `Given runtime profile When context loads Then expected bean is present`(beanName: String) {
+        assertTrue(
+            applicationContext.containsBean(beanName),
+            "Bean '$beanName' must be present in @ActiveProfiles(\"runtime\") context"
+        )
+    }
+
+    @ParameterizedTest(name = "Bean ''{0}'' MUST be absent in runtime profile")
+    @MethodSource("runtimeExpectedAbsentBeans")
+    fun `Given runtime profile When context loads Then generation bean is absent`(beanName: String) {
+        assertFalse(
+            applicationContext.containsBean(beanName),
+            "Bean '$beanName' must be absent in @ActiveProfiles(\"runtime\") context"
+        )
+    }
+
+    companion object {
+        /**
+         * Beans that MUST be present when @ActiveProfiles("runtime") is active.
+         */
+        @JvmStatic
+        fun runtimeExpectedPresentBeans() = listOf(
+            "runtimePrimingHook",
+            "mockNestConfig",
+            "wireMockServer",
+            "directCallHttpServer",
+            "runtimeLambdaHandler",
+            "adminRequestUseCase",
+            "clientRequestUseCase",
+            "runtimeMappingReloadHook",
+        )
+
+        /**
+         * Beans that MUST be absent when @ActiveProfiles("runtime") is active.
+         */
+        @JvmStatic
+        fun runtimeExpectedAbsentBeans() = listOf(
+            "generationPrimingHook",
+        )
+    }
+}


### PR DESCRIPTION
## Summary
fix issue with snapstart and loading mappings; and priming

## Related Issues
<!-- Reference any related issues: Fixes #123, Relates to #456 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CRaC/SnapStart lifecycle support and a runtime restore hook that reloads mock mappings after a Lambda restore.

* **Improvements**
  * Clearer separation between "runtime" and "generation" profiles to control component activation.
  * Lambdas now set SPRING_PROFILES_ACTIVE explicitly per role for predictable profile selection.

* **Tests**
  * Expanded profile-focused integration and unit tests validating profile isolation, SnapStart priming, and restore behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->