### PR TITLE
add self correction 2 passes

### DIFF
--- a/.kiro/steering/structure.md
+++ b/.kiro/steering/structure.md
@@ -4,7 +4,7 @@ MockNest Serverless consists of three main capabilities:
 
 1) **AI-Powered Mock Intelligence**: A comprehensive mock maintenance engine that analyzes traffic patterns, generates mocks from API specifications, detects specification changes, and provides intelligent mock suggestions and optimization recommendations to keep mock suites current and comprehensive
 2) **Core Mock Runtime**: A serverless WireMock runtime that serves mocked HTTP endpoints and exposes the WireMock admin API
-3) **Persistent Storage**: Stores mock definitions and response payloads outside the runtime so they remain available across executions (traffic logs and analysis results storage planned for future phases)
+3) **Persistent Storage**: Stores mock definitions, response payloads, and request journal entries outside the runtime so they remain available across executions (traffic analysis results storage planned for future phases)
 
 ## AI-Powered Mock Intelligence Flow
 The AI intelligence system provides intelligent mock generation and maintenance through dedicated admin endpoints:
@@ -88,7 +88,8 @@ flowchart TB
 
     subgraph Storage["Persistent Storage"]
         MOCKSTORE[(Mock Definitions)]
-        TRAFFICSTORE[(Traffic Logs - Future)]
+        REQUESTJOURNAL[(Request Journal - S3)]
+        TRAFFICSTORE[(Traffic Analysis - Future)]
         ANALYSISSTORE[(Analysis Results - Future)]
         SPECSTORE[(API Specifications - Future)]
     end
@@ -100,7 +101,7 @@ flowchart TB
     AIUSER -->|Enhancement requests| AIGENERATOR
 
     WM <--> MOCKSTORE
-    TRAFFIC --> TRAFFICSTORE
+    TRAFFIC --> REQUESTJOURNAL
     ANALYZER <--> TRAFFICSTORE
     SUGGESTER --> MOCKSTORE
     COVERAGE --> ANALYSISSTORE
@@ -274,6 +275,7 @@ mocknest-serverless/
 │       └── aws/          // AWS-specific code, including AWS Lambda
 │           ├── core/             // Shared AWS infrastructure
 │           ├── runtime/          // Runtime Lambda handler
+│           ├── runtime-async/    // RuntimeAsync Lambda handler (webhook/callback dispatch via SQS)
 │           ├── generation/       // Generation Lambda handler
 │           └── mocknest/         // MockNest WireMock integration
 │
@@ -351,7 +353,7 @@ mocknest-serverless/
 
 Infrastructure-as-code packaging and deployment using AWS SAM:
 - CI/CD via GitHub Actions
-- The goal is publication as an AWS Serverless Application Repository (SAR) application
+- Published as an [AWS Serverless Application Repository (SAR) application](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/021259937026/MockNest-Serverless)
 
 # AWS Services
 
@@ -368,7 +370,9 @@ flowchart TB
     subgraph AWS["AWS MockNest Serverless System"]
         APIGW[Amazon API Gateway]
         LAMBDA[AWS Lambda - MockNest Serverless Runtime]
-        S3[(Amazon S3 - Mappings & Payloads)]
+        LAMBDAASYNC[AWS Lambda - RuntimeAsync - Webhook Dispatch]
+        SQS[Amazon SQS - Webhook Queue]
+        S3[(Amazon S3 - Mappings, Payloads & Request Journal)]
 
         subgraph AI["AI-assisted Mock Generation (Optional)"]
             AIADMIN[AI Admin API]
@@ -385,6 +389,9 @@ flowchart TB
     AIUSER -->|AI Requests| AIADMIN
     APIGW --> LAMBDA
     LAMBDA <--> S3
+    LAMBDA -->|Webhook events| SQS
+    SQS --> LAMBDAASYNC
+    LAMBDAASYNC -->|Dispatches webhooks| S3
     KOOG -->|Writes generated mappings| S3
 ```
 
@@ -394,7 +401,8 @@ MockNest Serverless core runtime is built around these essential AWS services:
 
 - **AWS Lambda** - Serverless compute runtime for the WireMock engine
 - **Amazon API Gateway** - HTTP ingress and access control for both admin API and mocked endpoints (API key or IAM SigV4, configurable via AuthMode parameter)
-- **Amazon S3** - Persistent storage for WireMock mappings and response payloads (always deployed)
+- **Amazon S3** - Persistent storage for WireMock mappings, response payloads, and request journal (always deployed)
+- **Amazon SQS** - Asynchronous webhook/callback dispatch queue, consumed by the RuntimeAsync Lambda
 
 When AI features are enabled, additional services are used:
 - **Amazon Bedrock** - AI model access for the Koog-based mock generation agent (using Amazon Nova Pro as the officially supported model)
@@ -405,12 +413,22 @@ When AI features are enabled, additional services are used:
   - Cold start optimization is critical due to mapping loading at startup
   - Concurrency settings control horizontal scaling
   - Memory allocation impacts performance with large mock sets
+- **AWS Lambda - RuntimeAsync** - Handles asynchronous webhook/callback dispatch from SQS
+  - Triggered by SQS messages when mocks include webhook/callback definitions
+  - Supports AWS IAM SigV4 signing on outbound webhook requests
+
+## Messaging Services
+
+- **Amazon SQS** - Asynchronous message queue for webhook/callback dispatch
+  - Runtime Lambda enqueues webhook events; RuntimeAsync Lambda processes them
+  - Visibility timeout derived from webhook timeout configuration (per AWS best practice)
 
 ## Storage Services
 
 - **Amazon S3** - Primary storage for all persistent data
   - Mock definitions (WireMock mappings) stored as JSON files
   - Response payloads stored separately to reduce memory usage
+  - Request journal entries stored under `requests/` prefix with configurable retention
   - Bucket organization supports efficient loading and caching strategies
 
 ## AI/ML Services
@@ -449,7 +467,7 @@ When AI features are enabled, additional services are used:
   - Supports conditional deployment parameters for AI features
   - Default deployment excludes AI components (Free Tier compliant)
   - Users can opt-in to AI generation during SAR deployment
-- **AWS Serverless Application Repository (SAR)** - Target publication platform
+- **AWS Serverless Application Repository (SAR)** - [Published application](https://serverlessrepo.aws.amazon.com/applications/eu-west-1/021259937026/MockNest-Serverless) for one-click deployment
 - **AWS CloudFormation** - Underlying infrastructure provisioning (via SAM)
 
 ## Cost Optimization

--- a/.kiro/steering/tech.md
+++ b/.kiro/steering/tech.md
@@ -517,9 +517,9 @@ AI assistance for test creation, execution, and maintenance:
 
 - Add JUnit 6/Kotlin test coverage alongside new features, following the unit testing standards defined in the Code Generation Standards section above
 - **Use Kover for code coverage** - Apply `org.jetbrains.kotlinx.kover` plugin for Kotlin-optimized coverage reporting with better support for inline functions and coroutines
-- **Target 80% minimum aggregated code coverage** (enforced) across the entire project, aiming for 90%+ - run `./gradlew koverHtmlReport` to generate coverage reports and `./gradlew koverVerify` to enforce the 80% threshold
+- **Target 90% minimum aggregated code coverage** (enforced) across the entire project - run `./gradlew koverHtmlReport` to generate coverage reports and `./gradlew koverVerify` to enforce the 90% threshold
 - **Emphasize integration tests over unit tests** - Focus on comprehensive end-to-end testing that validates actual system behavior rather than artificial per-module coverage targets
-- **Aggregated coverage enforcement** - The 80% coverage minimum is enforced at the project level (aggregated across all modules) rather than per-module, allowing flexibility in test strategy while ensuring overall system quality
+- **Aggregated coverage enforcement** - The 90% coverage minimum is enforced at the project level (aggregated across all modules) rather than per-module, allowing flexibility in test strategy while ensuring overall system quality
 
 - **Property-based testing with @ParameterizedTest** - Use JUnit 6's `@ParameterizedTest` to validate universal properties across multiple examples:
   - Create comprehensive test data files covering edge cases (simple, complex, large, nested, etc.)
@@ -653,7 +653,7 @@ When generating implementation tasks (tasks.md), the following testing requireme
    - Every new class, function, or component MUST have corresponding unit tests
    - Unit tests MUST follow Given-When-Then naming convention
    - Unit tests MUST use MockK for mocking dependencies
-   - Unit tests MUST achieve minimum 80% code coverage for new code (matching the enforced project threshold)
+   - Unit tests MUST achieve minimum 90% code coverage for new code (matching the enforced project threshold)
    - Task example: "Write unit tests for [ComponentName] covering success and failure paths"
 
 2. **Property-Based Tests (MANDATORY)**
@@ -693,7 +693,7 @@ When generating implementation tasks (tasks.md), the following testing requireme
 Every task list MUST include a final verification task:
 ```markdown
 - [ ] N. Verify test coverage and quality
-  - [ ] N.1 Run `./gradlew koverHtmlReport` and verify 80%+ coverage for new code (enforced threshold; aim for 90%+ as a goal)
+  - [ ] N.1 Run `./gradlew koverHtmlReport` and verify 90%+ coverage for new code (enforced threshold)
   - [ ] N.2 Run `./gradlew koverVerify` to enforce coverage threshold
   - [ ] N.3 Review test quality: Given-When-Then naming, proper assertions, edge case coverage
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Before creating a bug report, please check existing issues to avoid duplicates. 
 
 Feature requests are welcome! Please:
 
-- Check if the feature aligns with our [project scope](.kiro/steering/01-scope-and-non-goals.md)
+- Check if the feature aligns with our [project scope](.kiro/steering/product.md#scope-and-non-goals)
 - Provide a clear description of the feature and its use case
 - Explain why this feature would be useful to MockNest Serverless users
 
@@ -34,11 +34,11 @@ Feature requests are welcome! Please:
 
 1. **Fork the repository** and create your branch from `main`
 2. **Follow our development setup** in [docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)
-3. **Make your changes** following our [coding standards](.kiro/steering/05-kiro-usage.md#code-generation-standards) and [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
+3. **Make your changes** following our [coding standards](.kiro/steering/tech.md#code-generation-standards) and [Kotlin coding conventions](https://kotlinlang.org/docs/coding-conventions.html)
 4. **Add tests** for any new functionality
-5. **Ensure all tests pass** and coverage remains at 90%+
+5. **Ensure all tests pass** and coverage meets threshold (90% minimum enforced via koverVerify)
 6. **If you changed prompt templates** under `software/application/src/main/resources/prompts/`, run the [Bedrock Prompt Eval Tests](docs/PROMPT_EVAL.md) before and after your change to measure impact on generation quality
-7. **Update documentation** if needed following our [documentation practices](.kiro/steering/05-kiro-usage.md#documentation-practices)
+7. **Update documentation** if needed following our [documentation practices](.kiro/steering/tech.md#documentation-practices)
 8. **Submit a pull request**
 
 #### Pull Request Guidelines
@@ -73,7 +73,7 @@ These workflows are called by the main pipelines above:
 
 | Workflow | Purpose | Used By |
 |----------|---------|---------|
-| **workflow-build.yml** | Build and test all modules, verify 90% coverage, upload to Codecov | Feature and Main branch pipelines |
+| **workflow-build.yml** | Build and test all modules, verify 90% coverage (enforced via koverVerify), upload to Codecov | Feature and Main branch pipelines |
 | **workflow-deploy-aws.yml** | Deploy to AWS using SAM | Feature and Main branch pipelines |
 | **workflow-sar-publish.yml** | Package and publish to AWS Serverless Application Repository | SAR Publish pipeline |
 
@@ -106,7 +106,7 @@ See [SAR Publishing Guide](docs/SAR_PUBLISHING.md) for detailed instructions.
 
 All pipelines use:
 - **Java 25** (Temurin distribution)
-- **Gradle 9.0.0** (via wrapper)
+- **Gradle 9.4.1** (via wrapper)
 - **AWS OIDC authentication** (no long-lived credentials)
 - **Kover** for code coverage reporting
 
@@ -147,8 +147,8 @@ For detailed MockNest Serverless guidelines, see our steering documentation:
 - **Code Quality & Standards**: [Code Generation Standards](.kiro/steering/tech.md#code-generation-standards)
 - **Testing Strategy**: [Testing Strategy](.kiro/steering/tech.md#testing-strategy)
 - **Prompt Evaluation**: [Bedrock Prompt Eval Tests](docs/PROMPT_EVAL.md) — run before and after any prompt template change
-- **Development Workflow**: [Development Workflow](.kiro/steering/05-kiro-usage.md#development-workflow)
-- **Project Structure**: [Project Structure](.kiro/steering/05-kiro-usage.md#project-structure)
+- **Development Workflow**: [Development Workflow](.kiro/steering/tech.md#development-workflow)
+- **Project Structure**: [Project Structure](.kiro/steering/structure.md#project-structure)
 
 ## Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -75,11 +75,11 @@ See [MockNest Serverless project](https://github.com/users/elenavanengelenmaslov
 
 Generation quality is measured using a 46-scenario eval suite across 12 API specifications, with automated structural validation and LLM-as-a-judge semantic checks.
 
-| Protocol | Scenarios | Valid (no retries) | Valid (1 retry) | Semantic pass | Avg cost | Avg latency |
-|----------|-----------|-------------------|-----------------|---------------|----------|-------------|
-| REST     | 16        | 98%               | 100%            | 94%           | $0.005   | 2.7s        |
-| GraphQL  | 15        | 84%               | 93%             | 87%           | $0.007   | 2.5s        |
-| SOAP     | 15        | 100%              | 100%            | 93%           | $0.006   | 3.6s        |
+| Protocol | Scenarios | Valid (no retries) | Valid (1 retry) | Valid (2 retries) | Semantic pass | Avg cost | Avg latency |
+|----------|-----------|-------------------|-----------------|-------------------|---------------|----------|-------------|
+| REST     | 16        | 93%               | 100%            | 100%              | 100%          | $0.005   | 2.5s        |
+| GraphQL  | 15        | 81%               | 93%             | 100%              | 100%          | $0.007   | 2.3s        |
+| SOAP     | 15        | 100%              | 100%            | 100%              | 93%           | $0.006   | 3.2s        |
 
 *Tested with Amazon Nova Pro (`eu-west-1`). Self-correction retries are configurable (0–2 via `BedrockGenerationMaxRetries`, default 1). Invalid mocks are filtered out — only valid mocks are returned. For full methodology see the [Prompt Eval Guide](docs/PROMPT_EVAL.md).*
 

--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -87,7 +87,7 @@ open software/infra/aws/runtime/build/reports/kover/html/index.html
 
 #### Coverage Verification
 ```bash
-# Verify 80% coverage threshold (fails build if under 80%)
+# Verify 90% coverage threshold (fails build if under 90%)
 ./gradlew koverVerify
 ```
 
@@ -118,12 +118,12 @@ sam local invoke MockNestRuntimeFunction --event events/test-event.json
 
 ### Feature Branches
 - Build and test all modules
-- Verify 80% code coverage
+- Verify 90% code coverage
 - No deployment
 
 ### Main Branch
 - Build and test all modules
-- Verify 80% code coverage
+- Verify 90% code coverage
 - Upload coverage to Codecov
 - Deploy to AWS
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -10,21 +10,21 @@ This guide covers the development workflow and practices for MockNest Serverless
 
 ## Development Workflow
 
-For detailed development workflow including module development order, multi-module Gradle workflow, and WireMock integration, see our [Development Workflow](../.kiro/steering/05-kiro-usage.md#development-workflow) in the steering documentation.
+For detailed development workflow including module development order, multi-module Gradle workflow, and WireMock integration, see our [Development Workflow](../.kiro/steering/tech.md#development-workflow) in the steering documentation.
 
 ## Code Quality Standards
 
 All coding standards, testing requirements, and quality guidelines are documented in our steering files:
 
-- **Code Standards**: [Code Generation Standards](../.kiro/steering/05-kiro-usage.md#code-generation-standards)
-- **Testing Strategy**: [Testing Strategy](../.kiro/steering/05-kiro-usage.md#testing-strategy)
-- **Code Review Process**: [Code Review Process](../.kiro/steering/05-kiro-usage.md#code-review-process)
+- **Code Standards**: [Code Generation Standards](../.kiro/steering/tech.md#code-generation-standards)
+- **Testing Strategy**: [Testing Strategy](../.kiro/steering/tech.md#testing-strategy)
+- **Code Review Process**: [Code Review Process](../.kiro/steering/tech.md#code-review-process)
 
 ## Key Development Practices
 
 ### Before Submitting a PR
 1. Ensure all tests pass: `./gradlew test`
-2. Verify coverage meets 90%: `./gradlew koverVerify`
+2. Verify coverage meets threshold: `./gradlew koverVerify` (90% minimum enforced)
 3. Run full build: `./gradlew build`
 4. If you changed prompt templates, run the [Bedrock Prompt Eval Tests](PROMPT_EVAL.md) before and after your change
 5. Follow the commit message guidelines in [CONTRIBUTING.md](../CONTRIBUTING.md)
@@ -32,7 +32,7 @@ All coding standards, testing requirements, and quality guidelines are documente
 ### Documentation Updates
 When making changes that affect architecture or behavior:
 - Update relevant steering documents in `.kiro/steering/`
-- Follow our [Documentation Practices](../.kiro/steering/05-kiro-usage.md#documentation-practices)
+- Follow our [Documentation Practices](../.kiro/steering/tech.md#documentation-practices)
 - Keep documentation aligned with actual implementation
 
 ## Reference Documentation

--- a/docs/api/mocknest-openapi.yaml
+++ b/docs/api/mocknest-openapi.yaml
@@ -55,7 +55,7 @@ paths:
         - OpenAPI 3.x (fully tested)
         - Swagger 2.0 (experimental - supported but not extensively tested)
         - GraphQL (via introspection endpoint URL or pre-fetched introspection JSON)
-        - WSDL/SOAP 1.1 and SOAP 1.2 (via inline XML content or remote URL)
+        - WSDL/SOAP 1.2 only (via inline XML content or remote URL; SOAP 1.1 bindings are not supported for AI generation)
       tags:
         - AI Generation
       requestBody:
@@ -88,7 +88,7 @@ paths:
                   options:
                     enableValidation: true
               soap-generation-url:
-                summary: Generate mocks from WSDL URL (SOAP 1.1)
+                summary: Generate mocks from WSDL URL (SOAP 1.2 only)
                 value:
                   namespace:
                     apiName: calculator
@@ -99,7 +99,7 @@ paths:
                   options:
                     enableValidation: true
               soap-generation-inline:
-                summary: Generate mocks from inline WSDL XML content (SOAP 1.1)
+                summary: Generate mocks from inline WSDL XML content (SOAP 1.2 only)
                 value:
                   namespace:
                     apiName: calculator
@@ -260,7 +260,7 @@ paths:
                         photoUrls:
                           - "https://cdn-fastly.petguide.com/media/2022/02/16/8235403/top-10-funniest-dog-breeds.jpg"
               soap-generation-response:
-                summary: Generated SOAP WireMock mappings (SOAP 1.1 calculator)
+                summary: Generated SOAP WireMock mappings (SOAP 1.2 calculator)
                 value:
                   mappings:
                     - priority: 1

--- a/software/infra/aws/generation/build.gradle.kts
+++ b/software/infra/aws/generation/build.gradle.kts
@@ -139,7 +139,7 @@ tasks.register<Test>("bedrockEval") {
     }
     failFast = false
     // Forward eval-related environment variables to the forked test JVM
-    listOf("BEDROCK_EVAL_ENABLED", "BEDROCK_EVAL_ITERATIONS", "BEDROCK_EVAL_FILTER", "AWS_REGION").forEach { key ->
+    listOf("BEDROCK_EVAL_ENABLED", "BEDROCK_EVAL_ITERATIONS", "BEDROCK_EVAL_FILTER", "BEDROCK_EVAL_MAX_RETRIES", "AWS_REGION").forEach { key ->
         System.getenv(key)?.let { environment(key, it) }
     }
 }

--- a/software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/ai/eval/BedrockPromptEvalTest.kt
+++ b/software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/ai/eval/BedrockPromptEvalTest.kt
@@ -74,6 +74,8 @@ class BedrockPromptEvalTest {
 
     private val region: String = System.getenv("AWS_REGION") ?: "eu-west-1"
 
+    private val maxRetries: Int = System.getenv("BEDROCK_EVAL_MAX_RETRIES")?.toIntOrNull()?.coerceIn(0, 2) ?: 1
+
     private val tokenUsageStore = TokenUsageStore()
 
     private val bedrockClient: BedrockRuntimeClient = TokenUsageCapturingClient(
@@ -182,7 +184,7 @@ class BedrockPromptEvalTest {
         logger.info {
             "Starting multi-protocol Bedrock prompt eval: ${scenarios.size} scenario(s), " +
                 "$iterationCount iteration(s) each, " +
-                "model=${modelConfiguration.getModelName()}, region=$region"
+                "model=${modelConfiguration.getModelName()}, region=$region, maxRetries=$maxRetries"
         }
 
         for (scenario in scenarios) {
@@ -388,7 +390,8 @@ class BedrockPromptEvalTest {
                 aiModelService = aiModelService,
                 specificationParser = OpenAPISpecificationParser(),
                 mockValidator = OpenAPIMockValidator(),
-                promptBuilder = promptBuilder
+                promptBuilder = promptBuilder,
+                maxRetries = maxRetries
             )
             "GRAPHQL" -> MockGenerationFunctionalAgent(
                 aiModelService = aiModelService,
@@ -397,7 +400,8 @@ class BedrockPromptEvalTest {
                     GraphQLSchemaReducer()
                 ),
                 mockValidator = GraphQLMockValidator(),
-                promptBuilder = promptBuilder
+                promptBuilder = promptBuilder,
+                maxRetries = maxRetries
             )
             "SOAP" -> MockGenerationFunctionalAgent(
                 aiModelService = aiModelService,
@@ -407,7 +411,8 @@ class BedrockPromptEvalTest {
                     WsdlSchemaReducer()
                 ),
                 mockValidator = SoapMockValidator(),
-                promptBuilder = promptBuilder
+                promptBuilder = promptBuilder,
+                maxRetries = maxRetries
             )
             else -> error("Unsupported protocol: $protocol")
         }

--- a/software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/ai/eval/BedrockPromptEvalTest.kt
+++ b/software/infra/aws/generation/src/test/kotlin/nl/vintik/mocknest/infra/aws/generation/ai/eval/BedrockPromptEvalTest.kt
@@ -52,9 +52,9 @@ private val logger = KotlinLogging.logger {}
  *
  * Exercises the real Koog + Bedrock generation prompt path against REST (OpenAPI),
  * GraphQL, and SOAP (WSDL) specifications. Reads scenarios from a dataset JSON,
- * runs each scenario with retry 0 (generation-only) and retry 1 (generation +
- * validation/correction), captures token usage, and produces a per-protocol
- * summary table.
+ * runs each scenario with configurable self-correction retries (controlled by
+ * `BEDROCK_EVAL_MAX_RETRIES`, default 1, range 0–2), captures token usage, and
+ * produces a per-protocol summary table.
  *
  * This test is excluded from normal `./gradlew test` runs via the `bedrock-eval`
  * JUnit tag and the `BEDROCK_EVAL_ENABLED` environment variable gate.
@@ -193,7 +193,7 @@ class BedrockPromptEvalTest {
             for (iter in 1..iterationCount) {
                 logger.info { "--- Iteration $iter/$iterationCount ---" }
 
-                // Single run with enableValidation=true (retry budget = 1)
+                // Single run with enableValidation=true (maxRetries controlled by BEDROCK_EVAL_MAX_RETRIES)
                 val result = runScenario(scenario)
                 results.add(result)
                 logScenarioResult(result)


### PR DESCRIPTION
## Summary
add 2 retries eval

## Related Issues
<!-- Reference any related issues: Fixes #123, Relates to #456 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated generation quality evaluation table to a retry-aware layout: adds a "Valid (2 retries)" column and replaces previous per-protocol metric columns with the new reported values.
  * Updated contribution and CI guidance links, coverage enforcement note, and CI Gradle wrapper version in contributing docs.

* **Chores**
  * Build/test orchestration now forwards a retry-limit environment setting into test runs.

* **Tests**
  * Tests made retry-configurable (0–2, default 1) to enable retry-aware evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->