### PR TITLE
do not load full response into memory when dribble is on

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,1 @@
-github: elenavanengelenmaslova
 buy_me_a_coffee: elenavanengelen

--- a/.kiro/specs/zero-memory-streaming/.config.kiro
+++ b/.kiro/specs/zero-memory-streaming/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "1123ae5a-2c5f-4bbb-bf01-604711100ba5", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/zero-memory-streaming/design.md
+++ b/.kiro/specs/zero-memory-streaming/design.md
@@ -1,0 +1,604 @@
+# Design Document: Zero-Memory Streaming
+
+## Overview
+
+This feature eliminates full body materialization when `chunkedDribbleDelay` is configured on a persistent mock whose response body has been externalized to S3. Currently, the handler loads the entire S3 file into memory as a `String`, converts it to a `ByteArray`, and then chunks it — consuming ~2× the payload size in heap. 
+
+The zero-memory streaming optimization introduces a new path where:
+1. The `ChunkedDribbleDelayCapture` transformer intercepts the `bodyFileName` before WireMock renders the response body
+2. The transformer returns a modified `ResponseDefinition` with the `bodyFileName` removed (preventing WireMock from loading the S3 file)
+3. The handler detects the captured `bodyFileName` and streams directly from S3 using bounded 1MB chunks with inter-chunk delays
+
+This keeps peak memory usage constant (~1MB) regardless of payload size, enabling chunked dribble delivery of payloads up to 200MB without memory pressure.
+
+## Architecture
+
+### Design Decision: Intercepting Before WireMock Renders
+
+The key architectural decision is to intercept the `bodyFileName` in the `ResponseDefinitionTransformerV2` (which runs before WireMock resolves the body) and return a modified `ResponseDefinition` without the `bodyFileName`. This prevents WireMock from loading the S3 file into memory via its standard body resolution path.
+
+**Why `ResponseDefinitionBuilder.like()`**: WireMock's `ResponseDefinitionBuilder.like(responseDefinition)` creates a builder pre-populated with all fields from an existing `ResponseDefinition`. We then call `.withBody("")` (which clears `bodyFileName` internally since body and bodyFileName are mutually exclusive in WireMock) to produce a new `ResponseDefinition` that WireMock will render with an empty body. The handler then ignores this empty body and streams from S3 instead.
+
+**Why not modify the response after WireMock renders**: If we let WireMock resolve the `bodyFileName`, it would load the entire file into memory — exactly what we're trying to avoid.
+
+### Design Decision: S3 HEAD Request for Size Validation
+
+Before streaming begins, the handler issues an S3 `HeadObject` request to get the `contentLength`. This allows the 200MB size check to happen without loading any body content, failing fast for oversized payloads.
+
+### Design Decision: Expanding CapturedDribbleConfig
+
+Rather than introducing a separate thread-local or side channel, we expand the existing `CapturedDribbleConfig` data class to include an optional `bodyFileName`. This keeps the communication between transformer and handler simple and contained in a single thread-local.
+
+### High-Level Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Handler as StreamingRuntimeLambdaHandler
+    participant WireMock
+    participant Transformer as ChunkedDribbleDelayCapture
+    participant S3 as S3ResponseStreamer
+    participant Writer as ChunkedResponseWriter
+
+    Client->>Handler: HTTP Request
+    Handler->>WireMock: routeRequest()
+    WireMock->>Transformer: transform(serveEvent)
+    
+    alt bodyFileName + dribble present
+        Transformer->>Transformer: Store bodyFileName + dribble in thread-local
+        Transformer-->>WireMock: Modified ResponseDefinition (empty body, no bodyFileName)
+    else dribble only (inline body)
+        Transformer->>Transformer: Store dribble params only in thread-local
+        Transformer-->>WireMock: Original ResponseDefinition unchanged
+    else no dribble
+        Transformer-->>WireMock: Original ResponseDefinition unchanged
+    end
+    
+    WireMock-->>Handler: HttpResponse (empty body for S3 path)
+    
+    alt CapturedDribbleConfig has bodyFileName
+        Handler->>S3: headObject(bodyFileName) → contentLength
+        Handler->>Handler: Validate size < 200MB
+        Handler->>Handler: Write metadata + delimiter
+        Handler->>S3: getObjectAsInputStream(bodyFileName)
+        Handler->>Writer: writeChunkedFromStream(inputStream, bodySize, chunks, duration, output)
+        Writer->>Writer: Read 1MB buffer, write chunk, delay, repeat
+    else CapturedDribbleConfig without bodyFileName (inline)
+        Handler->>Writer: writeChunked(bodyBytes, chunks, duration, output)
+    else No CapturedDribbleConfig
+        Handler->>Handler: protocolWriter.write(response, output)
+    end
+    
+    Handler-->>Client: Streaming Response
+```
+
+## Components and Interfaces
+
+### Modified `CapturedDribbleConfig`
+
+Expanded to include an optional `bodyFileName` field:
+
+```kotlin
+data class CapturedDribbleConfig(
+    val numberOfChunks: Int,
+    val totalDurationMs: Long,
+    val bodyFileName: String? = null,
+)
+```
+
+**Location**: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapture.kt`
+
+### Modified `ChunkedDribbleDelayCapture` Transformer
+
+The transformer gains new logic to detect `bodyFileName` + `chunkedDribbleDelay` combinations:
+
+```kotlin
+class ChunkedDribbleDelayCapture : ResponseDefinitionTransformerV2 {
+
+    override fun transform(serveEvent: ServeEvent): ResponseDefinition {
+        val responseDefinition = serveEvent.responseDefinition
+            ?: run {
+                capturedConfig.remove()
+                return ResponseDefinition.notConfigured()
+            }
+
+        val chunkedDribbleDelay = responseDefinition.chunkedDribbleDelay
+
+        if (chunkedDribbleDelay != null) {
+            val numberOfChunks = chunkedDribbleDelay.numberOfChunks
+            val totalDuration = chunkedDribbleDelay.totalDuration.toLong()
+
+            if (numberOfChunks >= 2 && totalDuration >= 0) {
+                val bodyFileName = responseDefinition.bodyFileName
+
+                if (bodyFileName != null) {
+                    // S3 streaming path: capture bodyFileName and return modified response
+                    logger.debug { "Captured chunkedDribbleDelay with bodyFileName: $bodyFileName" }
+                    capturedConfig.set(
+                        CapturedDribbleConfig(numberOfChunks, totalDuration, bodyFileName)
+                    )
+                    // Return a ResponseDefinition without bodyFileName to prevent WireMock from loading S3
+                    return ResponseDefinitionBuilder.like(responseDefinition)
+                        .withBody("")
+                        .build()
+                } else {
+                    // Inline body path: existing behavior
+                    logger.debug { "Captured chunkedDribbleDelay: numberOfChunks=$numberOfChunks, totalDuration=$totalDuration" }
+                    capturedConfig.set(CapturedDribbleConfig(numberOfChunks, totalDuration))
+                }
+            } else {
+                capturedConfig.remove()
+            }
+        } else {
+            capturedConfig.remove()
+        }
+
+        return responseDefinition
+    }
+}
+```
+
+**Key change**: When both `bodyFileName` and valid `chunkedDribbleDelay` are present, the transformer:
+1. Stores the `bodyFileName` in `CapturedDribbleConfig`
+2. Returns `ResponseDefinitionBuilder.like(responseDefinition).withBody("").build()` — this creates a new `ResponseDefinition` that preserves status, headers, etc. but has an empty body and no `bodyFileName`
+
+### Expanded `ChunkedResponseWriter`
+
+New `InputStream`-based method added alongside the existing `ByteArray`-based method:
+
+```kotlin
+class ChunkedResponseWriter {
+
+    companion object {
+        private const val IDLE_TIMEOUT_WARNING_THRESHOLD_MS = 270_000L
+        const val STREAM_BUFFER_SIZE = 1024 * 1024 // 1MB
+    }
+
+    /**
+     * Existing method: writes body from a ByteArray in chunks with delays.
+     */
+    suspend fun writeChunked(body: ByteArray, numberOfChunks: Int, totalDurationMs: Long, output: OutputStream) {
+        // ... existing implementation unchanged ...
+    }
+
+    /**
+     * New method: streams from an InputStream in bounded chunks with delays.
+     * Reads at most STREAM_BUFFER_SIZE (1MB) at a time, writes to output,
+     * then delays before the next read.
+     *
+     * @param input The InputStream to read from (e.g., S3 object stream)
+     * @param bodySize Total size of the body in bytes (from S3 HEAD)
+     * @param numberOfChunks Number of chunks to deliver
+     * @param totalDurationMs Total delay distributed between chunks
+     * @param output The OutputStream to write chunks to
+     */
+    suspend fun writeChunkedFromStream(
+        input: InputStream,
+        bodySize: Long,
+        numberOfChunks: Int,
+        totalDurationMs: Long,
+        output: OutputStream,
+    ) {
+        if (totalDurationMs > IDLE_TIMEOUT_WARNING_THRESHOLD_MS) {
+            logger.warn {
+                "Chunked dribble delay totalDuration ${totalDurationMs}ms exceeds ${IDLE_TIMEOUT_WARNING_THRESHOLD_MS}ms. " +
+                    "This may exceed the 5-minute streaming idle timeout."
+            }
+        }
+
+        val chunkSize = calculateStreamChunkSize(bodySize, numberOfChunks)
+        val delayBetweenChunks = totalDurationMs / numberOfChunks
+        val buffer = ByteArray(minOf(chunkSize.toInt(), STREAM_BUFFER_SIZE))
+
+        var totalBytesWritten = 0L
+        var chunkIndex = 0
+
+        while (totalBytesWritten < bodySize) {
+            if (chunkIndex > 0 && delayBetweenChunks > 0) {
+                delay(delayBetweenChunks)
+            }
+
+            // Read up to one chunk's worth of data (bounded by buffer size)
+            var chunkBytesWritten = 0L
+            val targetChunkBytes = chunkSize
+
+            while (chunkBytesWritten < targetChunkBytes) {
+                val toRead = minOf(
+                    buffer.size.toLong(),
+                    targetChunkBytes - chunkBytesWritten,
+                    bodySize - totalBytesWritten
+                ).toInt()
+                if (toRead <= 0) break
+
+                val bytesRead = input.read(buffer, 0, toRead)
+                if (bytesRead == -1) break
+
+                output.write(buffer, 0, bytesRead)
+                chunkBytesWritten += bytesRead
+                totalBytesWritten += bytesRead
+            }
+            output.flush()
+            chunkIndex++
+        }
+    }
+
+    /**
+     * Calculates the target chunk size for stream-based chunking.
+     */
+    internal fun calculateStreamChunkSize(bodySize: Long, numberOfChunks: Int): Long {
+        if (bodySize == 0L || numberOfChunks <= 0) return 0L
+        return (bodySize + numberOfChunks - 1) / numberOfChunks // ceiling division
+    }
+}
+```
+
+**Location**: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriter.kt`
+
+### Expanded `S3ResponseStreamer`
+
+New methods for getting content length and streaming with a consumer callback:
+
+```kotlin
+class S3ResponseStreamer(
+    private val s3Client: S3Client,
+    private val bucketName: String,
+) {
+
+    companion object {
+        const val BUFFER_SIZE = 1024 * 1024
+    }
+
+    /**
+     * Existing method: streams S3 content directly to an OutputStream.
+     */
+    fun streamToOutput(s3Key: String, output: OutputStream): Boolean { /* ... */ }
+
+    /**
+     * Gets the content length of an S3 object without downloading it.
+     * Uses HeadObject to retrieve metadata only.
+     *
+     * @param s3Key The S3 object key
+     * @return Content length in bytes, or null if the object doesn't exist or an error occurs
+     */
+    suspend fun getContentLength(s3Key: String): Long? =
+        runCatching {
+            s3Client.headObject(HeadObjectRequest {
+                bucket = bucketName
+                key = s3Key
+            }).contentLength
+        }.onFailure { exception ->
+            logger.error(exception) {
+                "Failed to get content length for S3 object: key=$s3Key, bucket=$bucketName"
+            }
+        }.getOrNull()
+
+    /**
+     * Streams S3 object content through a consumer callback, keeping the getObject
+     * lifecycle contained within this method. The consumer receives the InputStream
+     * and content length, and must consume the stream before returning.
+     *
+     * This design avoids returning an InputStream that would be invalid outside
+     * the Kotlin AWS SDK's getObject callback scope.
+     *
+     * @param s3Key The S3 object key
+     * @param consumer Callback that receives the InputStream and content length.
+     *                 Must consume the stream before returning.
+     * @return true if streaming completed successfully, false on error
+     */
+    suspend fun streamWithConsumer(
+        s3Key: String,
+        consumer: suspend (inputStream: InputStream, contentLength: Long) -> Unit,
+    ): Boolean =
+        runCatching {
+            s3Client.getObject(GetObjectRequest {
+                bucket = bucketName
+                key = s3Key
+            }) { response ->
+                val body = response.body
+                    ?: throw S3StreamingException("S3 object body is null for key: $s3Key")
+                val contentLength = response.contentLength ?: 0L
+                val inputStream = body.toInputStream()
+                consumer(inputStream, contentLength)
+            }
+            true
+        }.onFailure { exception ->
+            logger.error(exception) {
+                "Failed to stream S3 object with consumer: key=$s3Key, bucket=$bucketName"
+            }
+        }.getOrDefault(false)
+}
+```
+
+**Design Decision: Consumer Callback Pattern**
+
+The Kotlin AWS SDK's `getObject` lambda scope means the response body InputStream is only valid inside the callback. Returning it from a method would result in a closed/invalid stream. Instead, `S3ResponseStreamer` owns the `getObject` lifecycle and invokes a consumer callback with the InputStream. The consumer (the handler/writer) reads from the stream within the callback scope, ensuring the stream is valid throughout.
+
+This means the `ChunkedResponseWriter.writeChunkedFromStream` is called from within the S3 callback — the handler passes the output stream and dribble config, and the writer reads from S3 and writes to output with delays, all within the callback scope.
+
+**Location**: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt`
+
+### Modified `StreamingRuntimeLambdaHandler`
+
+The handler gains a new branch for S3 streaming with dribble:
+
+```kotlin
+class StreamingRuntimeLambdaHandler : RequestStreamHandler, KoinComponent {
+
+    // ... existing fields ...
+    private val s3ResponseStreamer: S3ResponseStreamer by inject()
+
+    override fun handleRequest(input: InputStream, output: OutputStream, context: Context) {
+        val httpRequest = parseRequest(input, output) ?: return
+        val path = httpRequest.path
+
+        ChunkedDribbleDelayCapture.clear()
+        val response = routeRequest(path, httpRequest)
+
+        // For client requests, check if chunkedDribbleDelay was captured
+        if (path.startsWith(MOCKNEST_PREFIX)) {
+            val dribbleConfig = ChunkedDribbleDelayCapture.getAndClear()
+            if (dribbleConfig != null) {
+                if (dribbleConfig.bodyFileName != null) {
+                    // NEW: S3 streaming path with chunked dribble
+                    writeS3ChunkedResponse(response, dribbleConfig, output)
+                    return
+                }
+                // Existing: in-memory chunked path
+                val bodyBytes = response.body?.toByteArray(Charsets.UTF_8)
+                if (bodyBytes != null && bodyBytes.isNotEmpty()) {
+                    writeChunkedResponse(response, bodyBytes, dribbleConfig, output)
+                    return
+                }
+            }
+        }
+
+        // Check response body size against 200MB limit (for non-S3 path)
+        val bodyBytes = response.body?.toByteArray(Charsets.UTF_8)
+        if (bodyBytes != null && bodyBytes.size > MAX_RESPONSE_SIZE_BYTES) {
+            writeErrorResponse(output, 502, "Response payload exceeds the maximum supported streaming limit of 200MB")
+            return
+        }
+
+        protocolWriter.write(response, output)
+        output.flush()
+    }
+
+    /**
+     * Streams response body from S3 with chunked dribble delays.
+     * Uses S3 HEAD for size validation, then streams with bounded memory
+     * via the consumer callback pattern (InputStream consumed within S3 callback scope).
+     */
+    private fun writeS3ChunkedResponse(
+        response: HttpResponse,
+        config: CapturedDribbleConfig,
+        output: OutputStream,
+    ) {
+        val bodyFileName = config.bodyFileName ?: return
+        val s3Key = "__files/$bodyFileName"
+
+        runBlocking {
+            // Size check via HEAD request
+            val contentLength = s3ResponseStreamer.getContentLength(s3Key)
+            if (contentLength == null) {
+                writeErrorResponse(output, 502, "Failed to retrieve S3 object metadata: $bodyFileName")
+                return@runBlocking
+            }
+            if (contentLength > MAX_RESPONSE_SIZE_BYTES) {
+                writeErrorResponse(output, 502, "Response payload exceeds the maximum supported streaming limit of 200MB")
+                return@runBlocking
+            }
+
+            // Write metadata + delimiter before streaming body
+            val headers = response.headers
+                ?.flatMap { (name, values) -> values.map { name to it } }
+                ?.toMap()
+                ?: emptyMap()
+            protocolWriter.writeMetadataAndDelimiter(response.statusCode.value, headers, output)
+
+            // Stream from S3 with chunked delays using consumer callback
+            // The InputStream is only valid inside the S3 callback scope
+            val success = s3ResponseStreamer.streamWithConsumer(s3Key) { inputStream, _ ->
+                chunkedWriter.writeChunkedFromStream(
+                    input = inputStream,
+                    bodySize = contentLength,
+                    numberOfChunks = config.numberOfChunks,
+                    totalDurationMs = config.totalDurationMs,
+                    output = output,
+                )
+            }
+
+            if (!success) {
+                logger.error { "S3 streaming with chunked dribble failed for key=$s3Key" }
+                // Note: metadata+delimiter already written, can't change status code
+                // Client will receive a truncated response
+            }
+            output.flush()
+        }
+    }
+}
+```
+
+**Location**: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandler.kt`
+
+## Data Models
+
+### `CapturedDribbleConfig` (Modified)
+
+```kotlin
+data class CapturedDribbleConfig(
+    val numberOfChunks: Int,
+    val totalDurationMs: Long,
+    val bodyFileName: String? = null,  // NEW: optional S3 body file reference
+)
+```
+
+### Data Flow: S3 Streaming with Dribble (New Path)
+
+```mermaid
+flowchart TD
+    A[Client Request] --> B[Handler: routeRequest]
+    B --> C[WireMock: match stub]
+    C --> D[Transformer: transform]
+    D --> E{bodyFileName + dribble?}
+    
+    E -->|Yes| F[Store bodyFileName + dribble in thread-local]
+    F --> G[Return ResponseDefinition with empty body]
+    G --> H[WireMock renders empty body response]
+    H --> I[Handler: getAndClear thread-local]
+    I --> J{bodyFileName present?}
+    
+    J -->|Yes| K[S3 HEAD: get contentLength]
+    K --> L{size < 200MB?}
+    L -->|Yes| M[S3 getInputStream]
+    M --> N[Write metadata + delimiter]
+    N --> O[writeChunkedFromStream: 1MB buffer, delays]
+    O --> P[Response delivered progressively]
+    
+    L -->|No| Q[502: Payload too large]
+    
+    E -->|No dribble| R[Return ResponseDefinition unchanged]
+    R --> S[Standard WireMock rendering]
+    S --> T[Handler: standard protocolWriter path]
+```
+
+### Data Flow: Inline Body with Dribble (Existing Path — Unchanged)
+
+```mermaid
+flowchart TD
+    A[Client Request] --> B[Handler: routeRequest]
+    B --> C[WireMock: match stub]
+    C --> D[Transformer: transform]
+    D --> E{dribble but no bodyFileName?}
+    
+    E -->|Yes| F[Store dribble params only in thread-local]
+    F --> G[Return ResponseDefinition unchanged]
+    G --> H[WireMock renders inline body response]
+    H --> I[Handler: getAndClear thread-local]
+    I --> J{bodyFileName present?}
+    
+    J -->|No| K[Get body bytes from response]
+    K --> L[Write metadata + delimiter]
+    L --> M[writeChunked: ByteArray path with delays]
+    M --> N[Response delivered progressively]
+```
+
+### Memory Usage Comparison
+
+| Scenario | Before (Current) | After (Zero-Memory) |
+|----------|------------------|---------------------|
+| 10MB body + dribble | ~20MB heap (String + ByteArray) | ~1MB heap (streaming buffer) |
+| 50MB body + dribble | ~100MB heap | ~1MB heap |
+| 200MB body + dribble | ~400MB heap (OOM likely) | ~1MB heap |
+| Inline body + dribble | Body size × 2 | Body size × 2 (unchanged) |
+| No dribble | Body loaded by WireMock | Body loaded by WireMock (unchanged) |
+
+## Correctness Properties
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Transformer captures bodyFileName and removes it from ResponseDefinition
+
+*For any* response definition containing both a valid `bodyFileName` and a valid `chunkedDribbleDelay` (numberOfChunks >= 2, totalDuration >= 0), the transformer SHALL store the `bodyFileName` in the `CapturedDribbleConfig` thread-local AND return a `ResponseDefinition` where `bodyFileName` is null and body is empty.
+
+**Validates: Requirements 1.1, 1.2**
+
+### Property 2: Transformer preserves response unchanged for inline dribble mocks
+
+*For any* response definition containing a valid `chunkedDribbleDelay` but no `bodyFileName`, the transformer SHALL return the original response definition unchanged AND store only `numberOfChunks` and `totalDurationMs` (with `bodyFileName` = null) in the thread-local.
+
+**Validates: Requirements 1.3, 4.2**
+
+### Property 3: Transformer is no-op when no dribble is configured
+
+*For any* response definition that does not contain a `chunkedDribbleDelay`, the transformer SHALL return the response definition unchanged AND not store any configuration in the thread-local, regardless of whether `bodyFileName` is present.
+
+**Validates: Requirements 1.4, 5.1**
+
+### Property 4: Handler routes to S3 streaming when bodyFileName is present
+
+*For any* `CapturedDribbleConfig` containing a non-null `bodyFileName`, the handler SHALL use the `S3ResponseStreamer` to stream the response body rather than using the in-memory body bytes, and SHALL write metadata+delimiter before the chunked body content.
+
+**Validates: Requirements 2.1, 2.2**
+
+### Property 5: Handler routes to ByteArray path when no bodyFileName
+
+*For any* `CapturedDribbleConfig` with a null `bodyFileName` and non-empty response body bytes, the handler SHALL use the existing `ByteArray`-based `writeChunked` method and SHALL NOT attempt S3 streaming.
+
+**Validates: Requirements 4.1, 4.3**
+
+### Property 6: Bounded memory during InputStream-based streaming
+
+*For any* input stream of size S (where S > 0), the `writeChunkedFromStream` method SHALL never hold more than 1MB (1,048,576 bytes) of response body content in memory at any time, regardless of the total body size or number of chunks configured.
+
+**Validates: Requirements 3.1, 3.2, 3.3**
+
+### Property 7: Streaming round-trip preserves body content byte-for-byte
+
+*For any* body content stored in S3, streaming it through `writeChunkedFromStream` with any valid `numberOfChunks` and `totalDurationMs` SHALL produce output that matches the original content byte-for-byte when all chunks are concatenated.
+
+**Validates: Requirements 7.2, 7.4**
+
+### Property 8: Chunked delivery distributes bytes across configured number of chunks
+
+*For any* body of size S > 0 and configured `numberOfChunks` N >= 2, the `writeChunkedFromStream` method SHALL deliver the body in at most N write-flush cycles, with each cycle writing approximately S/N bytes (±1 byte for remainder distribution).
+
+**Validates: Requirements 7.3**
+
+## Error Handling
+
+| Error Condition | Detection | Response | Recovery |
+|----------------|-----------|----------|----------|
+| S3 HEAD fails (object not found, access denied) | `getContentLength()` returns null | 502 with error message | Log error, return immediately |
+| S3 object exceeds 200MB | `contentLength > MAX_RESPONSE_SIZE_BYTES` | 502 with size limit message | Log error, return immediately |
+| S3 GET InputStream fails | `getInputStream()` returns null | 502 with error message | Log error, return immediately |
+| S3 stream read error mid-transfer | IOException during `input.read()` | Partial response (connection may be broken) | Log error, exception propagates |
+| Invalid dribble config (chunks < 2 or duration < 0) | Validation in transformer | No config stored, standard path used | Graceful fallback to non-chunked |
+
+### Error Handling Design Decisions
+
+1. **Fail-fast on HEAD**: The S3 HEAD request validates both existence and size before any streaming begins. This avoids partial responses for oversized or missing files.
+2. **502 for S3 failures**: All S3-related failures return 502 (Bad Gateway) since the mock server is acting as a gateway to S3 storage.
+3. **Mid-stream failures**: If the S3 stream fails after metadata+delimiter have been written, the client receives a partial response. This is acceptable because HTTP streaming inherently has this limitation — the status code has already been sent.
+
+## Testing Strategy
+
+### Unit Tests
+
+- **ChunkedDribbleDelayCapture transformer**: Test all four paths (bodyFileName+dribble, dribble-only, bodyFileName-only, neither)
+- **ChunkedResponseWriter.writeChunkedFromStream**: Test bounded memory, correct output, chunk distribution
+- **ChunkedResponseWriter.calculateStreamChunkSize**: Test edge cases (0 size, 1 chunk, more chunks than bytes)
+- **StreamingRuntimeLambdaHandler**: Test S3 streaming path routing, error handling (502 responses), fallback to inline path
+- **S3ResponseStreamer.getContentLength**: Test success and failure paths
+- **S3ResponseStreamer.getInputStream**: Test success and failure paths
+
+### Property-Based Tests
+
+Property-based testing is appropriate for this feature because:
+- The `ChunkedResponseWriter.writeChunkedFromStream` is a pure data transformation with clear input/output behavior
+- The transformer logic has universal properties that hold across all valid inputs
+- The input space (body sizes, chunk counts, durations) is large and continuous
+
+**Library**: JUnit 6 `@ParameterizedTest` with diverse test data files and `@MethodSource` for generated inputs.
+
+**Configuration**: Minimum 100 iterations per property test.
+
+**Tag format**: `Feature: zero-memory-streaming, Property {number}: {property_text}`
+
+Each correctness property (1-8) will be implemented as a property-based test:
+- Properties 1-3: Transformer behavior with generated ResponseDefinitions
+- Properties 4-5: Handler routing with generated CapturedDribbleConfigs
+- Property 6: Memory bound verification with varying stream sizes (1KB to 50MB)
+- Property 7: Round-trip data integrity with random body content
+- Property 8: Chunk distribution with varying sizes and chunk counts
+
+### Integration Tests
+
+- **LocalStack S3 + Handler end-to-end**: Create persistent mock with bodyFileName, invoke via handler, verify complete body received
+- **Varying sizes**: Test with <1MB, ~5MB, and ~50MB bodies
+- **Timing verification**: Verify progressive delivery timing matches configured duration
+
+### Post-Deploy Tests
+
+- **Progressive delivery verification**: Create large mock, curl with `--no-buffer`, measure incremental arrival
+- **Data integrity**: Verify complete body matches expected content
+- **Timing assertion**: Fail if response arrives within first 10% of configured duration

--- a/.kiro/specs/zero-memory-streaming/requirements.md
+++ b/.kiro/specs/zero-memory-streaming/requirements.md
@@ -1,0 +1,95 @@
+# Requirements Document
+
+## Introduction
+
+Zero-memory streaming eliminates full body materialization when `chunkedDribbleDelay` is configured on a persistent mock whose response body has been externalized to S3 via `NormalizeMappingBodyFilter`. Currently, the handler loads the entire S3 file into memory as a `String`, converts it to a `ByteArray`, and then chunks it — consuming ~2× the payload size in heap. This feature introduces a streaming path where the `ChunkedDribbleDelayCapture` transformer intercepts the `bodyFileName` before WireMock renders the response, and the handler streams directly from S3 in bounded 1MB chunks with inter-chunk delays, keeping peak memory usage constant regardless of payload size.
+
+## Glossary
+
+- **Transformer**: The `ChunkedDribbleDelayCapture` WireMock `ResponseDefinitionTransformerV2` extension that intercepts response definitions before rendering
+- **Handler**: The `StreamingRuntimeLambdaHandler` AWS Lambda request stream handler that routes requests and writes streaming responses
+- **S3ResponseStreamer**: Existing class that streams S3 object content to an `OutputStream` using a bounded 1MB buffer
+- **ChunkedResponseWriter**: Class responsible for splitting response body into chunks with configurable inter-chunk delays
+- **CapturedDribbleConfig**: Thread-local data class holding captured dribble configuration (number of chunks, total duration, and optionally the body file name)
+- **bodyFileName**: The S3 object key (relative to `__files/` prefix) referencing an externalized response body stored by `NormalizeMappingBodyFilter`
+- **Persistent_Mock**: A WireMock stub mapping with `persistent: true` (default) whose body is externalized to S3 as a file
+- **Inline_Mock**: A WireMock stub mapping with `persistent: false` whose body remains inline in the mapping JSON (not externalized)
+- **Dribble_Config**: The `chunkedDribbleDelay` configuration on a response definition specifying `numberOfChunks` and `totalDuration`
+- **Streaming_Buffer**: A fixed-size 1MB byte array used to read S3 content incrementally without loading the full object into memory
+- **Progressive_Delivery**: The observable behavior where response bytes arrive incrementally over time rather than all at once
+
+## Requirements
+
+### Requirement 1: Transformer Intercepts bodyFileName for Dribble Responses
+
+**User Story:** As a platform operator, I want the transformer to capture the bodyFileName and prevent WireMock from loading the S3 file, so that large response bodies are never materialized in memory.
+
+#### Acceptance Criteria
+
+1. WHEN a response definition contains both a `bodyFileName` and a `chunkedDribbleDelay` configuration, THE Transformer SHALL store the `bodyFileName` in the `CapturedDribbleConfig` thread-local alongside the dribble parameters
+2. WHEN a response definition contains both a `bodyFileName` and a `chunkedDribbleDelay` configuration, THE Transformer SHALL return a modified `ResponseDefinition` with the `bodyFileName` removed and an empty placeholder body set
+3. WHEN a response definition contains a `chunkedDribbleDelay` but no `bodyFileName`, THE Transformer SHALL return the response definition unchanged and store only the dribble parameters in the thread-local (existing behavior for inline mocks)
+4. WHEN a response definition contains a `bodyFileName` but no `chunkedDribbleDelay`, THE Transformer SHALL return the response definition unchanged and not store any configuration in the thread-local
+
+### Requirement 2: Handler Streams from S3 with Chunked Delays
+
+**User Story:** As a platform operator, I want the handler to stream the response body directly from S3 in chunks with delays when a bodyFileName is captured, so that large payloads are delivered progressively without memory pressure.
+
+#### Acceptance Criteria
+
+1. WHEN the `CapturedDribbleConfig` contains a `bodyFileName`, THE Handler SHALL stream the response body from S3 using the `S3ResponseStreamer` instead of using the in-memory body bytes
+2. WHEN streaming from S3 with dribble configuration, THE Handler SHALL write response metadata and delimiter first, then deliver the S3 content in chunks with inter-chunk delays matching the configured `numberOfChunks` and `totalDurationMs`
+3. WHEN streaming from S3 with dribble configuration, THE Handler SHALL use the `ChunkedResponseWriter` with an `InputStream`-based variant that reads from the S3 stream in bounded chunks
+4. IF the S3 object cannot be retrieved during streaming, THEN THE Handler SHALL log the error and return a 502 error response to the client
+
+### Requirement 3: Bounded Memory Usage During Streaming
+
+**User Story:** As a platform operator, I want peak memory usage for the response body to remain bounded at 1MB during chunked streaming from S3, so that Lambda memory is not exhausted by large payloads.
+
+#### Acceptance Criteria
+
+1. WHILE streaming a response body from S3 with chunked dribble delay, THE ChunkedResponseWriter SHALL hold at most one 1MB buffer of response body content in memory at any time
+2. THE ChunkedResponseWriter SHALL provide an `InputStream`-based `writeChunked` method that reads from the stream in increments no larger than 1MB and writes each increment to the output with the configured inter-chunk delay
+3. WHEN the total response body exceeds 1MB, THE ChunkedResponseWriter SHALL NOT accumulate the full body in memory before chunking begins
+
+### Requirement 4: Inline Body Dribble Mocks Continue Unchanged
+
+**User Story:** As a developer, I want inline body dribble mocks (persistent: false) to continue working with the existing in-memory chunking path, so that test mocks are not affected by the streaming optimization.
+
+#### Acceptance Criteria
+
+1. WHEN a `CapturedDribbleConfig` does not contain a `bodyFileName` and the response body bytes are available in memory, THE Handler SHALL use the existing `ByteArray`-based `writeChunked` method to deliver the response
+2. WHEN a response definition has `persistent: false` with an inline body and `chunkedDribbleDelay`, THE Transformer SHALL capture only the dribble parameters without a `bodyFileName` (existing behavior preserved)
+3. THE Handler SHALL NOT attempt S3 streaming when no `bodyFileName` is present in the captured configuration
+
+### Requirement 5: Non-Dribble Responses Remain Unaffected
+
+**User Story:** As a developer, I want non-dribble responses to continue flowing through the standard WireMock rendering and streaming protocol path, so that the optimization does not introduce regressions.
+
+#### Acceptance Criteria
+
+1. WHEN a response definition does not contain a `chunkedDribbleDelay`, THE Transformer SHALL NOT modify the response definition or store any thread-local configuration
+2. WHEN no `CapturedDribbleConfig` is present after routing, THE Handler SHALL write the response using the standard `StreamingProtocolWriter` path
+3. WHEN a response definition contains a `bodyFileName` but no `chunkedDribbleDelay`, THE Handler SHALL allow WireMock to load and render the file normally through its standard body resolution
+
+### Requirement 6: Post-Deploy Test Verifies Progressive Delivery
+
+**User Story:** As a platform operator, I want a post-deploy test that verifies chunked dribble responses are delivered progressively over time, so that I can confirm the streaming behavior works end-to-end in the deployed environment.
+
+#### Acceptance Criteria
+
+1. THE Post_Deploy_Test SHALL create a persistent mock with a response body larger than 1MB and a `chunkedDribbleDelay` configuration
+2. THE Post_Deploy_Test SHALL issue a curl request with `--no-buffer` and measure that response bytes arrive incrementally over the configured duration rather than all at once
+3. THE Post_Deploy_Test SHALL verify that the complete response body is received and matches the expected content
+4. IF the response arrives entirely within the first 10% of the configured total duration, THEN THE Post_Deploy_Test SHALL report a failure indicating progressive delivery is not working
+
+### Requirement 7: Integration Test Verifies Correct Body from S3 Streaming
+
+**User Story:** As a developer, I want an integration test that verifies the full response body arrives correctly when streamed from S3 with chunked dribble delay, so that I can confirm data integrity of the streaming path.
+
+#### Acceptance Criteria
+
+1. THE Integration_Test SHALL create a persistent mock with a known response body and `chunkedDribbleDelay` configuration
+2. THE Integration_Test SHALL verify that the complete response body received by the client matches the original body byte-for-byte
+3. THE Integration_Test SHALL verify that the response is delivered in the configured number of chunks (observable via timing or chunk boundaries)
+4. THE Integration_Test SHALL test with response bodies of varying sizes (small: <1MB, medium: ~5MB, large: ~50MB) to confirm the streaming path handles all sizes correctly

--- a/.kiro/specs/zero-memory-streaming/tasks.md
+++ b/.kiro/specs/zero-memory-streaming/tasks.md
@@ -1,0 +1,248 @@
+# Implementation Plan: Zero-Memory Streaming
+
+## Overview
+
+This plan implements the zero-memory streaming optimization for chunked dribble delay responses backed by S3 body files. The key change is intercepting `bodyFileName` in the transformer before WireMock loads the file, then streaming directly from S3 with bounded 1MB chunks and inter-chunk delays. The existing inline body dribble path remains unchanged.
+
+## Tasks
+
+- [x] 1. Expand CapturedDribbleConfig and modify ChunkedDribbleDelayCapture transformer
+  - [x] 1.1 Add optional `bodyFileName` field to `CapturedDribbleConfig` data class
+    - File: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapture.kt`
+    - Add `val bodyFileName: String? = null` as a third parameter with default value
+    - Existing callers continue to work due to default value
+    - _Requirements: 1.1_
+
+  - [x] 1.2 Modify `ChunkedDribbleDelayCapture.transform()` to intercept bodyFileName
+    - File: `software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapture.kt`
+    - Add import for `com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder`
+    - When both `bodyFileName` and valid `chunkedDribbleDelay` are present:
+      - Store `bodyFileName` in `CapturedDribbleConfig`
+      - Return `ResponseDefinitionBuilder.like(responseDefinition).withBody("").build()`
+    - When only `chunkedDribbleDelay` is present (no bodyFileName): existing behavior unchanged
+    - When only `bodyFileName` is present (no dribble): return unchanged, no thread-local stored
+    - When neither is present: return unchanged, clear thread-local
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [x] 1.3 Write unit tests for transformer covering all 4 paths
+    - File: `software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCaptureTest.kt`
+    - Test: bodyFileName + dribble → config has bodyFileName, returns modified ResponseDefinition with empty body
+    - Test: dribble only (no bodyFileName) → config has null bodyFileName, returns original ResponseDefinition
+    - Test: bodyFileName only (no dribble) → no config stored, returns original ResponseDefinition
+    - Test: neither bodyFileName nor dribble → no config stored, returns original ResponseDefinition
+    - Use MockK to mock `ServeEvent` and `ResponseDefinition`
+    - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+  - [x] 1.4 Run `./gradlew clean test` and confirm all tests pass
+
+- [x] 2. Add `writeChunkedFromStream` to ChunkedResponseWriter
+  - [x] 2.1 Implement `writeChunkedFromStream` method and `calculateStreamChunkSize` helper
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriter.kt`
+    - Add `STREAM_BUFFER_SIZE = 1024 * 1024` constant (1MB)
+    - Add `import java.io.InputStream` and `import kotlinx.coroutines.delay`
+    - Implement `suspend fun writeChunkedFromStream(input: InputStream, bodySize: Long, numberOfChunks: Int, totalDurationMs: Long, output: OutputStream)`
+    - Reads at most `STREAM_BUFFER_SIZE` bytes at a time from the InputStream
+    - Writes chunks to output with `delayBetweenChunks = totalDurationMs / numberOfChunks` between them
+    - Include idle timeout warning check (same as existing `writeChunked`)
+    - Implement `internal fun calculateStreamChunkSize(bodySize: Long, numberOfChunks: Int): Long` using ceiling division
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [x] 2.2 Write unit tests for `writeChunkedFromStream`
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterStreamTest.kt`
+    - Test: output matches input byte-for-byte for various sizes (1KB, 5MB, 10MB)
+    - Test: buffer never exceeds 1MB (verify by using a custom InputStream that tracks read sizes)
+    - Test: correct number of flush calls (one per chunk)
+    - Test: `calculateStreamChunkSize` edge cases (0 size, 1 chunk, more chunks than bytes)
+    - Use `runTest` for coroutine testing with virtual time
+    - _Requirements: 3.1, 3.2, 3.3_
+
+  - [x] 2.3 Run `./gradlew clean test` and confirm all tests pass
+
+- [x] 3. Add `getContentLength` and `getInputStream` to S3ResponseStreamer
+  - [x] 3.1 Implement `getContentLength` method using S3 HeadObject
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt`
+    - Add import for `aws.sdk.kotlin.services.s3.model.HeadObjectRequest`
+    - Implement `suspend fun getContentLength(s3Key: String): Long?` that calls `s3Client.headObject()` and returns `contentLength`
+    - Return null on failure, log error
+    - _Requirements: 2.1, 2.4_
+
+  - [x] 3.2 Implement `streamWithConsumer` method for S3 object streaming with callback
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt`
+    - Implement `suspend fun streamWithConsumer(s3Key: String, consumer: suspend (InputStream, Long) -> Unit): Boolean`
+    - The consumer callback receives the InputStream and contentLength, and must consume the stream before returning
+    - This keeps the getObject lifecycle contained within S3ResponseStreamer (InputStream is valid inside the callback scope)
+    - Return false on failure, log error
+    - _Requirements: 2.1, 2.3_
+
+  - [x] 3.3 Write unit tests for `getContentLength` and `streamWithConsumer`
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamerTest.kt`
+    - Test: `getContentLength` returns correct size for existing object
+    - Test: `getContentLength` returns null when object doesn't exist
+    - Test: `streamWithConsumer` invokes consumer with readable InputStream for existing object
+    - Test: `streamWithConsumer` returns false when object doesn't exist
+    - Test: consumer receives correct contentLength
+    - Use MockK to mock `S3Client`
+    - _Requirements: 2.1, 2.4_
+
+  - [x] 3.4 Run `./gradlew clean test` and confirm all tests pass
+
+- [x] 4. Add `writeS3ChunkedResponse` to StreamingRuntimeLambdaHandler
+  - [x] 4.1 Implement S3 streaming path in the handler
+    - File: `software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandler.kt`
+    - Inject `S3ResponseStreamer` via Koin: `private val s3ResponseStreamer: S3ResponseStreamer by inject()`
+    - Modify `handleRequest` to check `dribbleConfig.bodyFileName`:
+      - If non-null → call new `writeS3ChunkedResponse(response, dribbleConfig, output)`
+      - If null → existing inline body path (unchanged)
+    - Implement `private fun writeS3ChunkedResponse(response: HttpResponse, config: CapturedDribbleConfig, output: OutputStream)`:
+      - Construct S3 key: `"__files/${config.bodyFileName}"` (using `FILES_PREFIX` pattern)
+      - Call `s3ResponseStreamer.getContentLength(s3Key)` — if null, write 502 error
+      - Validate `contentLength <= MAX_RESPONSE_SIZE_BYTES` — if exceeded, write 502 error
+      - Write metadata + delimiter via `protocolWriter.writeMetadataAndDelimiter()`
+      - Call `s3ResponseStreamer.streamWithConsumer(s3Key) { inputStream, _ -> chunkedWriter.writeChunkedFromStream(...) }`
+      - The InputStream is consumed within the S3 callback scope (safe with Kotlin AWS SDK)
+      - If `streamWithConsumer` returns false, log error (metadata already written, can't change status)
+      - Flush output
+    - Move the 200MB size check for non-S3 path to after the dribble config check
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 4.1, 4.3, 5.2_
+
+  - [x] 4.2 Write unit tests for handler S3 streaming path
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerTest.kt`
+    - Add tests in a new `S3ChunkedStreamingPath` nested class:
+    - Test: When `CapturedDribbleConfig` has bodyFileName → calls S3ResponseStreamer, writes chunked response
+    - Test: When `getContentLength` returns null → writes 502 error
+    - Test: When content length exceeds 200MB → writes 502 error
+    - Test: When `streamWithConsumer` returns false → metadata already written, error logged
+    - Test: When `CapturedDribbleConfig` has no bodyFileName → uses existing ByteArray path (no S3 calls)
+    - Test: When bodyFileName is intercepted by transformer → response.body is empty/placeholder (proves WireMock didn't load the file)
+    - Use `ChunkedDribbleDelayCapture.setForTest()` to set up thread-local
+    - _Requirements: 2.1, 2.2, 2.4, 4.1, 4.3_
+
+  - [x] 4.3 Run `./gradlew clean test` and confirm all tests pass
+
+- [x] 5. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 6. Property-based tests for correctness properties
+  - [x] 6.1 Write property test for transformer bodyFileName interception
+    - **Property 1: Transformer captures bodyFileName and removes it from ResponseDefinition**
+    - **Validates: Requirements 1.1, 1.2**
+    - File: `software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt`
+    - Use `@ParameterizedTest` with `@MethodSource` generating diverse ResponseDefinitions with various bodyFileName values and dribble configs
+    - Assert: returned ResponseDefinition has null bodyFileName and empty body; thread-local has the original bodyFileName
+
+  - [x] 6.2 Write property test for transformer inline dribble preservation
+    - **Property 2: Transformer preserves response unchanged for inline dribble mocks**
+    - **Validates: Requirements 1.3, 4.2**
+    - File: `software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt`
+    - Use `@ParameterizedTest` with diverse inline body + dribble combinations
+    - Assert: returned ResponseDefinition is unchanged; thread-local has null bodyFileName
+
+  - [x] 6.3 Write property test for transformer no-op when no dribble
+    - **Property 3: Transformer is no-op when no dribble is configured**
+    - **Validates: Requirements 1.4, 5.1**
+    - File: `software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt`
+    - Use `@ParameterizedTest` with ResponseDefinitions that have no chunkedDribbleDelay (with and without bodyFileName)
+    - Assert: returned ResponseDefinition is unchanged; no thread-local stored
+
+  - [x] 6.4 Write property test for handler S3 routing
+    - **Property 4: Handler routes to S3 streaming when bodyFileName is present**
+    - **Validates: Requirements 2.1, 2.2**
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt`
+    - Use `@ParameterizedTest` with various bodyFileName values and dribble configs
+    - Assert: S3ResponseStreamer is called, metadata+delimiter written before body
+
+  - [x] 6.5 Write property test for handler ByteArray path routing
+    - **Property 5: Handler routes to ByteArray path when no bodyFileName**
+    - **Validates: Requirements 4.1, 4.3**
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt`
+    - Use `@ParameterizedTest` with CapturedDribbleConfigs that have null bodyFileName
+    - Assert: S3ResponseStreamer is NOT called, existing writeChunked path is used
+
+  - [x] 6.6 Write property test for bounded memory during streaming
+    - **Property 6: Bounded memory during InputStream-based streaming**
+    - **Validates: Requirements 3.1, 3.2, 3.3**
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt`
+    - Use `@ParameterizedTest` with `@MethodSource` generating InputStreams of varying sizes (1KB, 1MB, 5MB, 10MB, 50MB)
+    - Use a custom InputStream wrapper that asserts no single `read()` call requests more than 1MB
+    - Assert: buffer never exceeds STREAM_BUFFER_SIZE
+
+  - [x] 6.7 Write property test for streaming round-trip data integrity
+    - **Property 7: Streaming round-trip preserves body content byte-for-byte**
+    - **Validates: Requirements 7.2, 7.4**
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt`
+    - Use `@ParameterizedTest` with `@MethodSource` generating random byte arrays of various sizes
+    - Stream through `writeChunkedFromStream` with various numberOfChunks values
+    - Assert: output bytes match input bytes exactly
+
+  - [x] 6.8 Write property test for chunk distribution
+    - **Property 8: Chunked delivery distributes bytes across configured number of chunks**
+    - **Validates: Requirements 7.3**
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt`
+    - Use `@ParameterizedTest` with various body sizes and chunk counts
+    - Use a counting OutputStream that tracks flush calls
+    - Assert: number of flush calls equals numberOfChunks (±1 for edge cases)
+
+- [x] 7. Checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+- [x] 8. Integration test with LocalStack
+  - [x] 8.1 Write integration test for S3 streaming with chunked dribble delay
+    - File: `software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ZeroMemoryStreamingIntegrationTest.kt`
+    - Extend existing `StreamingIntegrationTest` pattern (LocalStack + real WireMock)
+    - Test: Create persistent mock with known body + `chunkedDribbleDelay` → invoke handler → verify complete body received byte-for-byte
+    - Test: Small body (<1MB) with dribble → verify correct delivery
+    - Test: Medium body (~5MB) with dribble → verify correct delivery
+    - Test: Verify delivery timing is progressive (elapsed time >= 80% of totalDuration)
+    - Test: Verify inline body dribble mock (persistent: false) still works unchanged
+    - _Requirements: 7.1, 7.2, 7.3, 7.4_
+
+  - [x] 8.2 Run `./gradlew clean test` and confirm all tests pass
+
+- [x] 9. Post-deploy test script for progressive delivery verification
+  - [x] 9.1 Add zero-memory streaming test to post-deploy script
+    - File: `scripts/post-deploy-test.sh`
+    - Add a test section that:
+      - Creates a persistent mock with a body larger than 1MB and `chunkedDribbleDelay` (e.g., 5 chunks, 5000ms total)
+      - Issues `curl --no-buffer` request and measures incremental byte arrival
+      - Verifies complete response body matches expected content
+      - Fails if response arrives entirely within first 10% of configured duration
+    - _Requirements: 6.1, 6.2, 6.3, 6.4_
+
+  - [x] 9.2 Run `./gradlew clean test` and confirm all tests pass
+
+- [x] 10. Final checkpoint - Ensure all tests pass
+  - Ensure all tests pass, ask the user if questions arise.
+
+## Notes
+
+- Tasks marked with `*` are optional and can be skipped for faster MVP
+- Each task references specific requirements for traceability
+- Checkpoints ensure incremental validation
+- Property tests validate universal correctness properties from the design document
+- Unit tests validate specific examples and edge cases
+- The existing inline body dribble path (persistent: false mocks) must remain unchanged — all existing tests must continue to pass
+- The Kotlin AWS SDK's `getObject` lambda scope constraint means the InputStream must be consumed within the lambda or a pipe approach must be used — task 3.2 addresses this
+- Use `ResponseDefinitionBuilder.like(responseDefinition).withBody("").build()` to create the modified ResponseDefinition (clears bodyFileName internally since body and bodyFileName are mutually exclusive in WireMock)
+- The S3 key prefix is `"__files/"` (from `FILES_PREFIX` constant in `ObjectStorageBlobStore.kt`)
+
+## Task Dependency Graph
+
+```json
+{
+  "waves": [
+    { "id": 0, "tasks": ["1.1"] },
+    { "id": 1, "tasks": ["1.2"] },
+    { "id": 2, "tasks": ["1.3", "2.1"] },
+    { "id": 3, "tasks": ["1.4", "2.2", "3.1"] },
+    { "id": 4, "tasks": ["2.3", "3.2"] },
+    { "id": 5, "tasks": ["3.3", "4.1"] },
+    { "id": 6, "tasks": ["3.4", "4.2"] },
+    { "id": 7, "tasks": ["4.3"] },
+    { "id": 8, "tasks": ["6.1", "6.2", "6.3", "6.6", "6.7", "6.8"] },
+    { "id": 9, "tasks": ["6.4", "6.5"] },
+    { "id": 10, "tasks": ["8.1"] },
+    { "id": 11, "tasks": ["8.2", "9.1"] },
+    { "id": 12, "tasks": ["9.2"] }
+  ]
+}
+```

--- a/scripts/post-deploy-test.sh
+++ b/scripts/post-deploy-test.sh
@@ -2436,6 +2436,171 @@ test_streaming_progressive_delivery() {
   echo "[streaming] ✓ Progressive delivery test completed"
 }
 
+# Test: Zero-memory streaming — large body (>1MB) with chunkedDribbleDelay
+# Creates a persistent mock with a body larger than 1MB and chunkedDribbleDelay,
+# issues curl --no-buffer to measure incremental byte arrival, verifies the
+# complete response body matches expected content, and fails if the response
+# arrives entirely within the first 10% of the configured total duration.
+# Validates: Requirements 6.1, 6.2, 6.3, 6.4
+test_streaming_zero_memory_progressive() {
+  echo "[streaming] Testing zero-memory streaming (>1MB body with chunkedDribbleDelay)..."
+
+  local NUM_CHUNKS=5
+  local TOTAL_DURATION_MS=5000
+  local BODY_SIZE=1100000  # ~1.1MB (exceeds 1MB threshold)
+
+  # Step 1: Generate a deterministic body larger than 1MB
+  echo "[streaming]   Generating ${BODY_SIZE}-byte payload..."
+  local LARGE_BODY
+  LARGE_BODY=$(python3 -c "print('X' * $BODY_SIZE)")
+
+  # Step 2: Register persistent mock with large body and chunkedDribbleDelay
+  echo "[streaming]   Registering persistent mock (body=${BODY_SIZE} bytes, chunks=$NUM_CHUNKS, totalDuration=${TOTAL_DURATION_MS}ms)..."
+  local mapping_body
+  mapping_body=$(python3 -c "
+import json
+body_content = 'X' * $BODY_SIZE
+mapping = {
+    'request': {
+        'method': 'GET',
+        'urlPath': '/streaming-test/zero-memory-progressive'
+    },
+    'response': {
+        'status': 200,
+        'body': body_content,
+        'headers': {
+            'Content-Type': 'application/octet-stream'
+        },
+        'chunkedDribbleDelay': {
+            'numberOfChunks': $NUM_CHUNKS,
+            'totalDuration': $TOTAL_DURATION_MS
+        }
+    },
+    'persistent': True
+}
+print(json.dumps(mapping))
+")
+
+  local response
+  response=$(curl "${CURL_OPTS[@]}" \
+    --write-out "\n%{http_code}" \
+    --request POST \
+    --data "$mapping_body" \
+    "$API_URL/__admin/mappings" 2>&1) || {
+    echo "[streaming] ERROR: Failed to register zero-memory streaming mock"
+    echo "[streaming] Response: $response"
+    exit 1
+  }
+  parse_response "$response"
+  if [ "$HTTP_CODE" != "201" ]; then
+    echo "[streaming] ERROR: Zero-memory streaming mock registration failed with HTTP $HTTP_CODE"
+    echo "[streaming] Response: $BODY"
+    exit 1
+  fi
+  local MAPPING_ID
+  MAPPING_ID=$(echo "$BODY" | json_field "id")
+  echo "[streaming]   ✓ Mock registered: $MAPPING_ID"
+
+  # Allow time for body externalization to S3
+  sleep 2
+
+  # Step 3: Invoke with --no-buffer and measure TTFB vs total time for progressive delivery
+  echo "[streaming]   Invoking mock with --no-buffer and measuring timing..."
+  local timing_output
+  timing_output=$(curl \
+    --silent \
+    --show-error \
+    --max-time 60 \
+    --no-buffer \
+    --header "x-api-key: $API_KEY" \
+    --output /tmp/zero-memory-streaming-response.bin \
+    --write-out "ttfb=%{time_starttransfer}\ntotal=%{time_total}\nsize=%{size_download}\n" \
+    "$API_URL/mocknest/streaming-test/zero-memory-progressive" 2>&1) || {
+    echo "[streaming] ERROR: Failed to invoke zero-memory streaming mock"
+    exit 1
+  }
+
+  local ttfb_seconds total_seconds received_bytes
+  ttfb_seconds=$(echo "$timing_output" | grep "^ttfb=" | cut -d= -f2)
+  total_seconds=$(echo "$timing_output" | grep "^total=" | cut -d= -f2)
+  received_bytes=$(echo "$timing_output" | grep "^size=" | cut -d= -f2)
+
+  local ttfb_ms total_ms
+  ttfb_ms=$(python3 -c "print(int(float('$ttfb_seconds') * 1000))")
+  total_ms=$(python3 -c "print(int(float('$total_seconds') * 1000))")
+
+  echo "[streaming]   TTFB: ${ttfb_ms}ms"
+  echo "[streaming]   Total: ${total_ms}ms"
+  echo "[streaming]   Received: ${received_bytes} bytes (expected: $BODY_SIZE)"
+
+  # Step 4: Verify complete response body matches expected content
+  echo "[streaming]   Verifying response body content..."
+  local actual_size
+  actual_size=$(wc -c < /tmp/zero-memory-streaming-response.bin | tr -d ' ')
+  if [ "$actual_size" -ne "$BODY_SIZE" ]; then
+    echo "[streaming] ERROR: Response size mismatch — expected $BODY_SIZE bytes, got $actual_size bytes"
+    rm -f /tmp/zero-memory-streaming-response.bin
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  fi
+
+  # Verify content is all 'X' characters (our deterministic payload)
+  local content_valid
+  content_valid=$(python3 -c "
+with open('/tmp/zero-memory-streaming-response.bin', 'r') as f:
+    content = f.read()
+    if content == 'X' * $BODY_SIZE:
+        print('true')
+    else:
+        print('false')
+")
+  if [ "$content_valid" != "true" ]; then
+    echo "[streaming] ERROR: Response body content does not match expected payload"
+    rm -f /tmp/zero-memory-streaming-response.bin
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[streaming]   ✓ Response body matches expected content (${BODY_SIZE} bytes of 'X')"
+
+  # Step 5: Verify progressive delivery — fail if response arrives within first 10% of duration
+  # If total_ms < 10% of TOTAL_DURATION_MS, the response arrived all at once (not progressive)
+  local ten_percent_ms
+  ten_percent_ms=$((TOTAL_DURATION_MS / 10))
+  echo "[streaming]   Progressive delivery check: total_ms=${total_ms}ms vs 10% threshold=${ten_percent_ms}ms"
+
+  if [ "$total_ms" -lt "$ten_percent_ms" ]; then
+    echo "[streaming] ERROR: Response arrived entirely within first 10% of configured duration (${total_ms}ms < ${ten_percent_ms}ms)"
+    echo "[streaming] This indicates progressive delivery is NOT working — response was delivered all at once"
+    rm -f /tmp/zero-memory-streaming-response.bin
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[streaming]   ✓ Progressive delivery confirmed: response took ${total_ms}ms (> ${ten_percent_ms}ms threshold)"
+
+  # Additional check: TTFB should be significantly less than total time for true streaming
+  local ttfb_ratio
+  ttfb_ratio=$(python3 -c "print(f'{float($ttfb_ms) / max(float($total_ms), 1) * 100:.1f}')")
+  echo "[streaming]   TTFB/Total ratio: ${ttfb_ratio}% (lower = more progressive)"
+
+  if python3 -c "exit(0 if float('$ttfb_ms') < float('$total_ms') * 0.5 else 1)"; then
+    echo "[streaming]   ✓ STREAMING CONFIRMED: TTFB (${ttfb_ms}ms) < 50% of total (${total_ms}ms)"
+  else
+    echo "[streaming]   ⚠ NOTE: TTFB (${ttfb_ms}ms) >= 50% of total (${total_ms}ms)"
+    echo "[streaming]   Response delivery timing suggests possible buffering at the edge layer"
+    # Don't fail — the 10% check above is the hard requirement
+  fi
+
+  # Step 6: Cleanup
+  echo "[streaming]   Cleaning up..."
+  rm -f /tmp/zero-memory-streaming-response.bin
+  curl "${CURL_OPTS[@]}" \
+    --request DELETE \
+    "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+  echo "[streaming]   ✓ Cleanup complete"
+
+  echo "[streaming] ✓ Zero-memory streaming progressive delivery test passed"
+}
+
 # Test: Unmatched mock returns 404 with no body
 # Verifies that calling a path with no matching mock returns HTTP 404
 # and does not return a body from a different mock.
@@ -2615,6 +2780,7 @@ main() {
       test_streaming_standard_body
       test_streaming_custom_headers
       test_streaming_progressive_delivery
+      test_streaming_zero_memory_progressive
       test_streaming_unmatched_returns_404
       test_streaming_multiple_mocks_correct_match
       ;;
@@ -2688,6 +2854,7 @@ main() {
       test_streaming_standard_body
       test_streaming_custom_headers
       test_streaming_progressive_delivery
+      test_streaming_zero_memory_progressive
       test_streaming_unmatched_returns_404
       test_streaming_multiple_mocks_correct_match
       ;;

--- a/scripts/post-deploy-test.sh
+++ b/scripts/post-deploy-test.sh
@@ -2601,6 +2601,195 @@ with open('/tmp/zero-memory-streaming-response.bin', 'r') as f:
   echo "[streaming] ✓ Zero-memory streaming progressive delivery test passed"
 }
 
+# Tests client-visible progressive streaming using SSE (Server-Sent Events).
+# Creates a mock with multiple "data:" lines and chunkedDribbleDelay, then uses
+# curl --no-buffer to timestamp each received line. Fails if:
+# - The first event arrives only near the end (>80% of total duration elapsed)
+# - All events arrive together (spread < 30% of total duration)
+# Validates: Requirements 6.1, 6.2, 6.3, 6.4
+test_streaming_sse_progressive_lines() {
+  echo "[streaming] Testing SSE line-based progressive streaming..."
+
+  local NUM_CHUNKS=5
+  local TOTAL_DURATION_MS=5000
+  local NUM_EVENTS=5
+
+  # Step 1: Build SSE body with multiple "data:" lines
+  local sse_body=""
+  for i in $(seq 1 $NUM_EVENTS); do
+    sse_body="${sse_body}data: event-${i}\n"
+  done
+
+  # Step 2: Register persistent mock with SSE body and chunkedDribbleDelay
+  echo "[streaming]   Registering SSE mock (${NUM_EVENTS} events, ${NUM_CHUNKS} chunks, ${TOTAL_DURATION_MS}ms)..."
+  local mapping_body
+  mapping_body=$(python3 -c "
+import json
+sse_lines = ''.join([f'data: event-{i}\n' for i in range(1, $NUM_EVENTS + 1)])
+mapping = {
+    'request': {
+        'method': 'GET',
+        'urlPath': '/streaming-test/sse-progressive'
+    },
+    'response': {
+        'status': 200,
+        'body': sse_lines,
+        'headers': {
+            'Content-Type': 'text/event-stream',
+            'Cache-Control': 'no-cache'
+        },
+        'chunkedDribbleDelay': {
+            'numberOfChunks': $NUM_CHUNKS,
+            'totalDuration': $TOTAL_DURATION_MS
+        }
+    },
+    'persistent': True
+}
+print(json.dumps(mapping))
+")
+
+  local response
+  response=$(curl "${CURL_OPTS[@]}" \
+    --write-out "\n%{http_code}" \
+    --request POST \
+    --data "$mapping_body" \
+    "$API_URL/__admin/mappings" 2>&1) || {
+    echo "[streaming] ERROR: Failed to register SSE progressive mock"
+    echo "[streaming] Response: $response"
+    exit 1
+  }
+  parse_response "$response"
+  if [ "$HTTP_CODE" != "201" ]; then
+    echo "[streaming] ERROR: SSE progressive mock registration failed with HTTP $HTTP_CODE"
+    echo "[streaming] Response: $BODY"
+    exit 1
+  fi
+  local MAPPING_ID
+  MAPPING_ID=$(echo "$BODY" | json_field "id")
+  echo "[streaming]   ✓ Mock registered: $MAPPING_ID"
+
+  # Allow time for body externalization to S3
+  sleep 2
+
+  # Step 3: Use curl --no-buffer and timestamp each received "data:" line
+  echo "[streaming]   Invoking SSE mock with --no-buffer, timestamping each line..."
+  local timestamp_script='/tmp/sse-timestamp-lines.py'
+  cat > "$timestamp_script" << 'PYTHON_SCRIPT'
+import subprocess
+import time
+import sys
+import os
+
+api_url = sys.argv[1]
+api_key = sys.argv[2]
+
+curl_cmd = [
+    'curl', '--silent', '--show-error', '--no-buffer', '--max-time', '30',
+    '--header', f'x-api-key: {api_key}',
+    api_url
+]
+
+start_time = time.time()
+timestamps = []
+lines_received = []
+
+proc = subprocess.Popen(curl_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, bufsize=0)
+
+# Read line by line as they arrive
+for raw_line in iter(proc.stdout.readline, b''):
+    line = raw_line.decode('utf-8', errors='replace').rstrip('\n').rstrip('\r')
+    now = time.time()
+    elapsed_ms = int((now - start_time) * 1000)
+    if line.startswith('data:'):
+        timestamps.append(elapsed_ms)
+        lines_received.append(line)
+
+proc.wait()
+
+# Output results
+for i, (ts, line) in enumerate(zip(timestamps, lines_received)):
+    print(f"LINE {i+1}: {ts}ms — {line}")
+
+if timestamps:
+    print(f"FIRST_EVENT_MS={timestamps[0]}")
+    print(f"LAST_EVENT_MS={timestamps[-1]}")
+    print(f"SPREAD_MS={timestamps[-1] - timestamps[0]}")
+    print(f"TOTAL_EVENTS={len(timestamps)}")
+else:
+    print("FIRST_EVENT_MS=0")
+    print("LAST_EVENT_MS=0")
+    print("SPREAD_MS=0")
+    print("TOTAL_EVENTS=0")
+PYTHON_SCRIPT
+
+  local timing_output
+  timing_output=$(python3 "$timestamp_script" \
+    "$API_URL/mocknest/streaming-test/sse-progressive" \
+    "$API_KEY" 2>&1) || {
+    echo "[streaming] ERROR: Failed to invoke SSE progressive mock"
+    rm -f "$timestamp_script"
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  }
+
+  echo "[streaming]   Line timestamps:"
+  echo "$timing_output" | grep "^LINE" | while read -r line; do
+    echo "[streaming]     $line"
+  done
+
+  local first_event_ms last_event_ms spread_ms total_events
+  first_event_ms=$(echo "$timing_output" | grep "^FIRST_EVENT_MS=" | cut -d= -f2)
+  last_event_ms=$(echo "$timing_output" | grep "^LAST_EVENT_MS=" | cut -d= -f2)
+  spread_ms=$(echo "$timing_output" | grep "^SPREAD_MS=" | cut -d= -f2)
+  total_events=$(echo "$timing_output" | grep "^TOTAL_EVENTS=" | cut -d= -f2)
+
+  echo "[streaming]   First event at: ${first_event_ms}ms"
+  echo "[streaming]   Last event at: ${last_event_ms}ms"
+  echo "[streaming]   Spread: ${spread_ms}ms"
+  echo "[streaming]   Events received: ${total_events}"
+
+  # Step 4: Validate all events were received
+  if [ "$total_events" -lt "$NUM_EVENTS" ]; then
+    echo "[streaming] ERROR: Expected $NUM_EVENTS events, only received $total_events"
+    rm -f "$timestamp_script"
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[streaming]   ✓ All $NUM_EVENTS events received"
+
+  # Step 5: Fail if first event arrives only near the end (>80% of total duration elapsed)
+  local eighty_percent_ms=$((TOTAL_DURATION_MS * 80 / 100))
+  if [ "$first_event_ms" -gt "$eighty_percent_ms" ]; then
+    echo "[streaming] ERROR: First event arrived at ${first_event_ms}ms — after 80% of ${TOTAL_DURATION_MS}ms (${eighty_percent_ms}ms)"
+    echo "[streaming] This indicates the response is being buffered and delivered all at once near the end"
+    rm -f "$timestamp_script"
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[streaming]   ✓ First event arrived early (${first_event_ms}ms < ${eighty_percent_ms}ms threshold)"
+
+  # Step 6: Fail if all events arrive together (spread < 30% of total duration)
+  local thirty_percent_ms=$((TOTAL_DURATION_MS * 30 / 100))
+  if [ "$spread_ms" -lt "$thirty_percent_ms" ]; then
+    echo "[streaming] ERROR: All events arrived within ${spread_ms}ms spread — less than 30% of ${TOTAL_DURATION_MS}ms (${thirty_percent_ms}ms)"
+    echo "[streaming] This indicates events are NOT being delivered progressively"
+    rm -f "$timestamp_script"
+    curl "${CURL_OPTS[@]}" --request DELETE "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+    exit 1
+  fi
+  echo "[streaming]   ✓ Events spread across ${spread_ms}ms (> ${thirty_percent_ms}ms threshold) — progressive delivery confirmed"
+
+  # Step 7: Cleanup
+  echo "[streaming]   Cleaning up..."
+  rm -f "$timestamp_script"
+  curl "${CURL_OPTS[@]}" \
+    --request DELETE \
+    "$API_URL/__admin/mappings/$MAPPING_ID" 2>/dev/null || true
+  echo "[streaming]   ✓ Cleanup complete"
+
+  echo "[streaming] ✓ SSE line-based progressive streaming test passed"
+}
+
 # Test: Unmatched mock returns 404 with no body
 # Verifies that calling a path with no matching mock returns HTTP 404
 # and does not return a body from a different mock.
@@ -2781,6 +2970,7 @@ main() {
       test_streaming_custom_headers
       test_streaming_progressive_delivery
       test_streaming_zero_memory_progressive
+      test_streaming_sse_progressive_lines
       test_streaming_unmatched_returns_404
       test_streaming_multiple_mocks_correct_match
       ;;
@@ -2855,6 +3045,7 @@ main() {
       test_streaming_custom_headers
       test_streaming_progressive_delivery
       test_streaming_zero_memory_progressive
+      test_streaming_sse_progressive_lines
       test_streaming_unmatched_returns_404
       test_streaming_multiple_mocks_correct_match
       ;;

--- a/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapture.kt
+++ b/software/application/src/main/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapture.kt
@@ -1,5 +1,6 @@
 package nl.vintik.mocknest.application.runtime.extensions
 
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.extension.ResponseDefinitionTransformerV2
 import com.github.tomakehurst.wiremock.http.ResponseDefinition
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent
@@ -35,8 +36,24 @@ class ChunkedDribbleDelayCapture : ResponseDefinitionTransformerV2 {
             val totalDuration = chunkedDribbleDelay.totalDuration.toLong()
 
             if (numberOfChunks >= 2 && totalDuration >= 0) {
-                logger.debug { "Captured chunkedDribbleDelay: numberOfChunks=$numberOfChunks, totalDuration=$totalDuration" }
-                capturedConfig.set(CapturedDribbleConfig(numberOfChunks, totalDuration))
+                val bodyFileName = responseDefinition.bodyFileName
+
+                if (bodyFileName != null) {
+                    // S3 streaming path: capture bodyFileName and return modified response
+                    logger.debug { "Captured chunkedDribbleDelay with bodyFileName: $bodyFileName" }
+                    capturedConfig.set(
+                        CapturedDribbleConfig(numberOfChunks, totalDuration, bodyFileName)
+                    )
+                    // Return a ResponseDefinition without bodyFileName to prevent WireMock from loading S3
+                    return ResponseDefinitionBuilder.like(responseDefinition)
+                        .withBodyFile(null)
+                        .withBody("")
+                        .build()
+                } else {
+                    // Inline body path: existing behavior
+                    logger.debug { "Captured chunkedDribbleDelay: numberOfChunks=$numberOfChunks, totalDuration=$totalDuration" }
+                    capturedConfig.set(CapturedDribbleConfig(numberOfChunks, totalDuration))
+                }
             } else {
                 capturedConfig.remove()
             }
@@ -44,7 +61,6 @@ class ChunkedDribbleDelayCapture : ResponseDefinitionTransformerV2 {
             capturedConfig.remove()
         }
 
-        // Return the response definition unchanged — we only capture, don't modify
         return responseDefinition
     }
 
@@ -81,4 +97,5 @@ class ChunkedDribbleDelayCapture : ResponseDefinitionTransformerV2 {
 data class CapturedDribbleConfig(
     val numberOfChunks: Int,
     val totalDurationMs: Long,
+    val bodyFileName: String? = null,
 )

--- a/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt
+++ b/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt
@@ -1,0 +1,272 @@
+package nl.vintik.mocknest.application.runtime.extensions
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Property-based tests for ChunkedDribbleDelayCapture transformer.
+ *
+ * Uses @ParameterizedTest with @MethodSource to validate universal properties
+ * across diverse ResponseDefinition inputs.
+ */
+class ChunkedDribbleDelayCapturePropertyTest {
+
+    private val serveEvent: ServeEvent = mockk(relaxed = true)
+    private val transformer = ChunkedDribbleDelayCapture()
+
+    @BeforeEach
+    fun setUp() {
+        ChunkedDribbleDelayCapture.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearMocks(serveEvent)
+        ChunkedDribbleDelayCapture.clear()
+    }
+
+    // =========================================================================
+    // Property 1: Transformer captures bodyFileName and removes it from ResponseDefinition
+    // Validates: Requirements 1.1, 1.2
+    // =========================================================================
+
+    /**
+     * **Validates: Requirements 1.1, 1.2**
+     *
+     * For any response definition containing both a valid bodyFileName and a valid
+     * chunkedDribbleDelay (numberOfChunks >= 2, totalDuration >= 0), the transformer
+     * SHALL store the bodyFileName in the CapturedDribbleConfig thread-local AND return
+     * a ResponseDefinition where bodyFileName is null and body is empty.
+     */
+    @ParameterizedTest
+    @MethodSource("bodyFileNameWithDribbleProvider")
+    @Tag("Feature: zero-memory-streaming, Property 1: Transformer captures bodyFileName and removes it from ResponseDefinition")
+    fun `Given bodyFileName and dribble config When transform Then captures bodyFileName and returns modified ResponseDefinition`(
+        testCase: BodyFileNameDribbleTestCase,
+    ) {
+        // Given
+        val responseDefinition = ResponseDefinitionBuilder()
+            .withStatus(testCase.statusCode)
+            .withBodyFile(testCase.bodyFileName)
+            .withChunkedDribbleDelay(testCase.numberOfChunks, testCase.totalDuration)
+            .build()
+
+        every { serveEvent.responseDefinition } returns responseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then - thread-local has the original bodyFileName
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNotNull(config, "Config should be stored for bodyFileName=${testCase.bodyFileName}")
+        assertEquals(testCase.bodyFileName, config.bodyFileName)
+        assertEquals(testCase.numberOfChunks, config.numberOfChunks)
+        assertEquals(testCase.totalDuration.toLong(), config.totalDurationMs)
+
+        // Then - returned ResponseDefinition has no bodyFileName and empty body
+        assertNull(result.bodyFileName, "Returned ResponseDefinition should have null bodyFileName")
+        assertTrue(
+            result.body.isNullOrEmpty() || result.body == "",
+            "Returned ResponseDefinition should have empty body",
+        )
+    }
+
+    // =========================================================================
+    // Property 2: Transformer preserves response unchanged for inline dribble mocks
+    // Validates: Requirements 1.3, 4.2
+    // =========================================================================
+
+    /**
+     * **Validates: Requirements 1.3, 4.2**
+     *
+     * For any response definition containing a valid chunkedDribbleDelay but no bodyFileName,
+     * the transformer SHALL return the original response definition unchanged AND store only
+     * numberOfChunks and totalDurationMs (with bodyFileName = null) in the thread-local.
+     */
+    @ParameterizedTest
+    @MethodSource("inlineDribbleProvider")
+    @Tag("Feature: zero-memory-streaming, Property 2: Transformer preserves response unchanged for inline dribble mocks")
+    fun `Given inline body with dribble config When transform Then preserves response and stores dribble params only`(
+        testCase: InlineDribbleTestCase,
+    ) {
+        // Given
+        val responseDefinition = ResponseDefinitionBuilder()
+            .withStatus(testCase.statusCode)
+            .withBody(testCase.inlineBody)
+            .withChunkedDribbleDelay(testCase.numberOfChunks, testCase.totalDuration)
+            .build()
+
+        every { serveEvent.responseDefinition } returns responseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then - returned ResponseDefinition is unchanged (same object)
+        assertSame(responseDefinition, result, "Response should be returned unchanged for inline dribble")
+
+        // Then - thread-local has dribble params but no bodyFileName
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNotNull(config, "Config should be stored for inline dribble")
+        assertEquals(testCase.numberOfChunks, config.numberOfChunks)
+        assertEquals(testCase.totalDuration.toLong(), config.totalDurationMs)
+        assertNull(config.bodyFileName, "bodyFileName should be null for inline dribble")
+    }
+
+    // =========================================================================
+    // Property 3: Transformer is no-op when no dribble is configured
+    // Validates: Requirements 1.4, 5.1
+    // =========================================================================
+
+    /**
+     * **Validates: Requirements 1.4, 5.1**
+     *
+     * For any response definition that does not contain a chunkedDribbleDelay, the transformer
+     * SHALL return the response definition unchanged AND not store any configuration in the
+     * thread-local, regardless of whether bodyFileName is present.
+     */
+    @ParameterizedTest
+    @MethodSource("noDribbleProvider")
+    @Tag("Feature: zero-memory-streaming, Property 3: Transformer is no-op when no dribble is configured")
+    fun `Given response without chunkedDribbleDelay When transform Then returns unchanged and no thread-local stored`(
+        testCase: NoDribbleTestCase,
+    ) {
+        // Given
+        val builder = ResponseDefinitionBuilder().withStatus(testCase.statusCode)
+
+        if (testCase.bodyFileName != null) {
+            builder.withBodyFile(testCase.bodyFileName)
+        }
+        if (testCase.inlineBody != null) {
+            builder.withBody(testCase.inlineBody)
+        }
+
+        val responseDefinition = builder.build()
+        every { serveEvent.responseDefinition } returns responseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then - returned ResponseDefinition is the SAME object as the input
+        assertSame(
+            responseDefinition,
+            result,
+            "Response should be returned unchanged when no dribble: ${testCase.description}",
+        )
+
+        // Then - no thread-local config stored
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNull(
+            config,
+            "No config should be stored when no dribble is configured: ${testCase.description}",
+        )
+    }
+
+    // =========================================================================
+    // Test data classes
+    // =========================================================================
+
+    data class BodyFileNameDribbleTestCase(
+        val bodyFileName: String,
+        val numberOfChunks: Int,
+        val totalDuration: Int,
+        val statusCode: Int,
+        val description: String,
+    )
+
+    data class InlineDribbleTestCase(
+        val inlineBody: String,
+        val numberOfChunks: Int,
+        val totalDuration: Int,
+        val statusCode: Int,
+        val description: String,
+    )
+
+    data class NoDribbleTestCase(
+        val bodyFileName: String?,
+        val inlineBody: String?,
+        val statusCode: Int,
+        val description: String,
+    )
+
+    companion object {
+
+        @JvmStatic
+        fun bodyFileNameWithDribbleProvider(): Stream<BodyFileNameDribbleTestCase> = Stream.of(
+            BodyFileNameDribbleTestCase("large-response.json", 5, 3000, 200, "JSON file with 5 chunks"),
+            BodyFileNameDribbleTestCase("payload.xml", 10, 5000, 200, "XML file with 10 chunks"),
+            BodyFileNameDribbleTestCase("binary-data.bin", 2, 1000, 200, "Binary file with minimum chunks"),
+            BodyFileNameDribbleTestCase("nested/path/response.json", 3, 2000, 201, "Nested path with 201 status"),
+            BodyFileNameDribbleTestCase("huge-payload.dat", 100, 60000, 200, "Large chunk count"),
+            BodyFileNameDribbleTestCase("response-with-spaces in name.json", 4, 4000, 200, "Filename with spaces"),
+            BodyFileNameDribbleTestCase("unicode-файл.json", 5, 2500, 200, "Unicode filename"),
+            BodyFileNameDribbleTestCase("a.txt", 2, 0, 200, "Minimum duration (0ms)"),
+            BodyFileNameDribbleTestCase("deep/nested/dir/file.json", 7, 7000, 404, "404 status with dribble"),
+            BodyFileNameDribbleTestCase("error-response.xml", 3, 1500, 500, "500 status with dribble"),
+            BodyFileNameDribbleTestCase("image.png", 20, 10000, 200, "Image file with many chunks"),
+            BodyFileNameDribbleTestCase("very-long-filename-that-represents-a-complex-api-response-body.json", 5, 5000, 200, "Long filename"),
+            BodyFileNameDribbleTestCase("response.html", 2, 500, 302, "302 redirect status"),
+            BodyFileNameDribbleTestCase("data.csv", 15, 15000, 200, "CSV file with 15 chunks"),
+            BodyFileNameDribbleTestCase("minimal.txt", 2, 100, 204, "204 No Content status"),
+        )
+
+        @JvmStatic
+        fun inlineDribbleProvider(): Stream<InlineDribbleTestCase> = Stream.of(
+            InlineDribbleTestCase("{\"status\":\"ok\"}", 3, 2000, 200, "Simple JSON body"),
+            InlineDribbleTestCase("<response><status>ok</status></response>", 5, 3000, 200, "XML body"),
+            InlineDribbleTestCase("plain text response", 2, 1000, 200, "Plain text body"),
+            InlineDribbleTestCase("", 3, 1500, 200, "Empty string body"),
+            InlineDribbleTestCase("a", 2, 500, 200, "Single character body"),
+            InlineDribbleTestCase("{\"data\":{\"nested\":{\"deep\":true}}}", 4, 4000, 200, "Nested JSON"),
+            InlineDribbleTestCase("x".repeat(1000), 10, 5000, 200, "1KB inline body"),
+            InlineDribbleTestCase("{\"error\":\"not found\"}", 2, 1000, 404, "404 error response"),
+            InlineDribbleTestCase("{\"error\":\"internal\"}", 3, 2000, 500, "500 error response"),
+            InlineDribbleTestCase("Line1\nLine2\nLine3", 2, 1000, 200, "Multi-line body"),
+            InlineDribbleTestCase("{\"items\":[1,2,3,4,5]}", 5, 2500, 201, "201 with array body"),
+            InlineDribbleTestCase("Special chars: <>&\"'", 2, 800, 200, "Special characters"),
+            InlineDribbleTestCase("\t\n\r", 2, 600, 200, "Whitespace-only body"),
+            InlineDribbleTestCase("Unicode: こんにちは世界", 3, 1500, 200, "Unicode content"),
+            InlineDribbleTestCase("{\"key\":\"value\",\"number\":42,\"bool\":true}", 4, 3000, 200, "Mixed JSON types"),
+        )
+
+        @JvmStatic
+        fun noDribbleProvider(): Stream<NoDribbleTestCase> = Stream.of(
+            // With bodyFileName only (various file names)
+            NoDribbleTestCase("large-response.json", null, 200, "JSON bodyFileName, no dribble"),
+            NoDribbleTestCase("payload.xml", null, 200, "XML bodyFileName, no dribble"),
+            NoDribbleTestCase("binary-data.bin", null, 200, "Binary bodyFileName, no dribble"),
+            NoDribbleTestCase("nested/path/file.json", null, 201, "Nested path bodyFileName, 201 status"),
+            NoDribbleTestCase("image.png", null, 200, "Image bodyFileName, no dribble"),
+            NoDribbleTestCase("unicode-файл.json", null, 200, "Unicode bodyFileName, no dribble"),
+            // With inline body only (various content)
+            NoDribbleTestCase(null, "{\"status\":\"ok\"}", 200, "JSON inline body, no dribble"),
+            NoDribbleTestCase(null, "<xml>content</xml>", 200, "XML inline body, no dribble"),
+            NoDribbleTestCase(null, "plain text", 200, "Plain text inline body, no dribble"),
+            NoDribbleTestCase(null, "x".repeat(5000), 200, "Large inline body, no dribble"),
+            NoDribbleTestCase(null, "", 200, "Empty inline body, no dribble"),
+            // With various status codes
+            NoDribbleTestCase("error.json", null, 404, "404 status with bodyFileName, no dribble"),
+            NoDribbleTestCase(null, "{\"error\":\"server\"}", 500, "500 status with inline body, no dribble"),
+            NoDribbleTestCase("redirect.html", null, 302, "302 status with bodyFileName, no dribble"),
+            NoDribbleTestCase(null, "created", 201, "201 status with inline body, no dribble"),
+            // With neither bodyFileName nor inline body (empty response)
+            NoDribbleTestCase(null, null, 200, "Empty response, 200 status, no dribble"),
+            NoDribbleTestCase(null, null, 204, "Empty response, 204 status, no dribble"),
+            NoDribbleTestCase(null, null, 404, "Empty response, 404 status, no dribble"),
+            NoDribbleTestCase(null, null, 500, "Empty response, 500 status, no dribble"),
+        )
+    }
+}

--- a/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt
+++ b/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCapturePropertyTest.kt
@@ -54,7 +54,8 @@ class ChunkedDribbleDelayCapturePropertyTest {
      */
     @ParameterizedTest
     @MethodSource("bodyFileNameWithDribbleProvider")
-    @Tag("Feature: zero-memory-streaming, Property 1: Transformer captures bodyFileName and removes it from ResponseDefinition")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-1-Transformer-captures-bodyFileName-and-removes-it-from-ResponseDefinition")
     fun `Given bodyFileName and dribble config When transform Then captures bodyFileName and returns modified ResponseDefinition`(
         testCase: BodyFileNameDribbleTestCase,
     ) {
@@ -99,7 +100,8 @@ class ChunkedDribbleDelayCapturePropertyTest {
      */
     @ParameterizedTest
     @MethodSource("inlineDribbleProvider")
-    @Tag("Feature: zero-memory-streaming, Property 2: Transformer preserves response unchanged for inline dribble mocks")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-2-Transformer-preserves-response-unchanged-for-inline-dribble-mocks")
     fun `Given inline body with dribble config When transform Then preserves response and stores dribble params only`(
         testCase: InlineDribbleTestCase,
     ) {
@@ -140,7 +142,8 @@ class ChunkedDribbleDelayCapturePropertyTest {
      */
     @ParameterizedTest
     @MethodSource("noDribbleProvider")
-    @Tag("Feature: zero-memory-streaming, Property 3: Transformer is no-op when no dribble is configured")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-3-Transformer-is-no-op-when-no-dribble-is-configured")
     fun `Given response without chunkedDribbleDelay When transform Then returns unchanged and no thread-local stored`(
         testCase: NoDribbleTestCase,
     ) {

--- a/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCaptureTest.kt
+++ b/software/application/src/test/kotlin/nl/vintik/mocknest/application/runtime/extensions/ChunkedDribbleDelayCaptureTest.kt
@@ -1,0 +1,125 @@
+package nl.vintik.mocknest.application.runtime.extensions
+
+import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
+import com.github.tomakehurst.wiremock.stubbing.ServeEvent
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ChunkedDribbleDelayCaptureTest {
+
+    private val serveEvent: ServeEvent = mockk(relaxed = true)
+
+    private val transformer = ChunkedDribbleDelayCapture()
+
+    @BeforeEach
+    fun setUp() {
+        ChunkedDribbleDelayCapture.clear()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearMocks(serveEvent)
+        ChunkedDribbleDelayCapture.clear()
+    }
+
+    @Test
+    fun `Given bodyFileName and dribble When transform Then config has bodyFileName and returns modified ResponseDefinition with empty body`() {
+        // Given - use a real ResponseDefinition so ResponseDefinitionBuilder.like() works
+        val realResponseDefinition = ResponseDefinitionBuilder()
+            .withStatus(200)
+            .withBodyFile("large-response.json")
+            .withChunkedDribbleDelay(5, 3000)
+            .build()
+
+        every { serveEvent.responseDefinition } returns realResponseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNotNull(config)
+        assertEquals(5, config.numberOfChunks)
+        assertEquals(3000L, config.totalDurationMs)
+        assertEquals("large-response.json", config.bodyFileName)
+
+        // Verify the returned ResponseDefinition has empty body and no bodyFileName
+        assertNull(result.bodyFileName)
+        assertTrue(result.body.isNullOrEmpty() || result.body == "")
+    }
+
+    @Test
+    fun `Given dribble only without bodyFileName When transform Then config has null bodyFileName and returns original ResponseDefinition`() {
+        // Given - use a real ResponseDefinition with inline body and dribble (no bodyFileName)
+        val realResponseDefinition = ResponseDefinitionBuilder()
+            .withStatus(200)
+            .withBody("inline response body")
+            .withChunkedDribbleDelay(3, 2000)
+            .build()
+
+        every { serveEvent.responseDefinition } returns realResponseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNotNull(config)
+        assertEquals(3, config.numberOfChunks)
+        assertEquals(2000L, config.totalDurationMs)
+        assertNull(config.bodyFileName)
+
+        // Verify the original ResponseDefinition is returned unchanged
+        assertEquals(realResponseDefinition, result)
+    }
+
+    @Test
+    fun `Given bodyFileName only without dribble When transform Then no config stored and returns original ResponseDefinition`() {
+        // Given - use a real ResponseDefinition with bodyFileName but no dribble
+        val realResponseDefinition = ResponseDefinitionBuilder()
+            .withStatus(200)
+            .withBodyFile("some-file.json")
+            .build()
+
+        every { serveEvent.responseDefinition } returns realResponseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNull(config)
+
+        // Verify the original ResponseDefinition is returned unchanged
+        assertEquals(realResponseDefinition, result)
+    }
+
+    @Test
+    fun `Given neither bodyFileName nor dribble When transform Then no config stored and returns original ResponseDefinition`() {
+        // Given - use a real ResponseDefinition with no bodyFileName and no dribble
+        val realResponseDefinition = ResponseDefinitionBuilder()
+            .withStatus(200)
+            .withBody("simple response")
+            .build()
+
+        every { serveEvent.responseDefinition } returns realResponseDefinition
+
+        // When
+        val result = transformer.transform(serveEvent)
+
+        // Then
+        val config = ChunkedDribbleDelayCapture.getAndClear()
+        assertNull(config)
+
+        // Verify the original ResponseDefinition is returned unchanged
+        assertEquals(realResponseDefinition, result)
+    }
+}

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandler.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandler.kt
@@ -23,6 +23,7 @@ import nl.vintik.mocknest.infra.aws.runtime.di.runtimeModule
 import nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimeMappingReloadHook
 import nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimePrimingHook
 import nl.vintik.mocknest.infra.aws.runtime.streaming.ChunkedResponseWriter
+import nl.vintik.mocknest.infra.aws.runtime.streaming.S3ResponseStreamer
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import java.io.InputStream
@@ -58,6 +59,7 @@ class StreamingRuntimeLambdaHandler : RequestStreamHandler, KoinComponent {
     private val handleClientRequest: HandleClientRequest by inject()
     private val handleAdminRequest: HandleAdminRequest by inject()
     private val getRuntimeHealth: GetRuntimeHealth by inject()
+    private val s3ResponseStreamer: S3ResponseStreamer by inject()
 
     private val requestParser = ApiGatewayRequestParser()
     private val protocolWriter = StreamingProtocolWriter()
@@ -75,21 +77,30 @@ class StreamingRuntimeLambdaHandler : RequestStreamHandler, KoinComponent {
 
         val response = routeRequest(path, httpRequest)
 
-        // Check response body size against 200MB limit
+        // For client requests, check if chunkedDribbleDelay was captured by the transformer
+        if (path.startsWith(MOCKNEST_PREFIX)) {
+            val dribbleConfig = ChunkedDribbleDelayCapture.getAndClear()
+            if (dribbleConfig != null) {
+                if (dribbleConfig.bodyFileName != null) {
+                    // S3 streaming path with chunked dribble
+                    writeS3ChunkedResponse(response, dribbleConfig, output)
+                    return
+                }
+                // Existing: in-memory chunked path
+                val bodyBytes = response.body?.toByteArray(Charsets.UTF_8)
+                if (bodyBytes != null && bodyBytes.isNotEmpty()) {
+                    writeChunkedResponse(response, bodyBytes, dribbleConfig, output)
+                    return
+                }
+            }
+        }
+
+        // Check response body size against 200MB limit (for non-S3 path)
         val bodyBytes = response.body?.toByteArray(Charsets.UTF_8)
         if (bodyBytes != null && bodyBytes.size > MAX_RESPONSE_SIZE_BYTES) {
             logger.error { "Response body size ${bodyBytes.size} exceeds maximum supported streaming limit of ${MAX_RESPONSE_SIZE_BYTES} bytes" }
             writeErrorResponse(output, 502, "Response payload exceeds the maximum supported streaming limit of 200MB")
             return
-        }
-
-        // For client requests, check if chunkedDribbleDelay was captured by the transformer
-        if (path.startsWith(MOCKNEST_PREFIX)) {
-            val dribbleConfig = ChunkedDribbleDelayCapture.getAndClear()
-            if (dribbleConfig != null && bodyBytes != null && bodyBytes.isNotEmpty()) {
-                writeChunkedResponse(response, bodyBytes, dribbleConfig, output)
-                return
-            }
         }
 
         // Write standard streaming response
@@ -155,6 +166,59 @@ class StreamingRuntimeLambdaHandler : RequestStreamHandler, KoinComponent {
             chunkedWriter.writeChunked(bodyBytes, config.numberOfChunks, config.totalDurationMs, output)
         }
         output.flush()
+    }
+
+    /**
+     * Streams response body from S3 with chunked dribble delays.
+     * Uses S3 HEAD for size validation, then streams with bounded memory
+     * via the consumer callback pattern (InputStream consumed within S3 callback scope).
+     */
+    private fun writeS3ChunkedResponse(
+        response: HttpResponse,
+        config: CapturedDribbleConfig,
+        output: OutputStream,
+    ) {
+        val bodyFileName = config.bodyFileName ?: return
+        val s3Key = "__files/$bodyFileName"
+
+        runBlocking {
+            // Size check via HEAD request
+            val contentLength = s3ResponseStreamer.getContentLength(s3Key)
+            if (contentLength == null) {
+                writeErrorResponse(output, 502, "Failed to retrieve S3 object metadata: $bodyFileName")
+                return@runBlocking
+            }
+            if (contentLength > MAX_RESPONSE_SIZE_BYTES) {
+                writeErrorResponse(output, 502, "Response payload exceeds the maximum supported streaming limit of 200MB")
+                return@runBlocking
+            }
+
+            // Write metadata + delimiter before streaming body
+            val headers = response.headers
+                ?.flatMap { (name, values) -> values.map { name to it } }
+                ?.toMap()
+                ?: emptyMap()
+            protocolWriter.writeMetadataAndDelimiter(response.statusCode.value, headers, output)
+
+            // Stream from S3 with chunked delays using consumer callback
+            // The InputStream is only valid inside the S3 callback scope
+            val success = s3ResponseStreamer.streamWithConsumer(s3Key) { inputStream, _ ->
+                chunkedWriter.writeChunkedFromStream(
+                    input = inputStream,
+                    bodySize = contentLength,
+                    numberOfChunks = config.numberOfChunks,
+                    totalDurationMs = config.totalDurationMs,
+                    output = output,
+                )
+            }
+
+            if (!success) {
+                logger.error { "S3 streaming with chunked dribble failed for key=$s3Key" }
+                // Note: metadata+delimiter already written, can't change status code
+                // Client will receive a truncated response
+            }
+            output.flush()
+        }
     }
 
     /**

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandler.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandler.kt
@@ -172,6 +172,9 @@ class StreamingRuntimeLambdaHandler : RequestStreamHandler, KoinComponent {
      * Streams response body from S3 with chunked dribble delays.
      * Uses S3 HEAD for size validation, then streams with bounded memory
      * via the consumer callback pattern (InputStream consumed within S3 callback scope).
+     *
+     * Uses ETag from HEAD to ensure the same object version is streamed (prevents
+     * TOCTOU issues if the object is replaced between HEAD and GET).
      */
     private fun writeS3ChunkedResponse(
         response: HttpResponse,
@@ -182,30 +185,35 @@ class StreamingRuntimeLambdaHandler : RequestStreamHandler, KoinComponent {
         val s3Key = "__files/$bodyFileName"
 
         runBlocking {
-            // Size check via HEAD request
-            val contentLength = s3ResponseStreamer.getContentLength(s3Key)
-            if (contentLength == null) {
+            // Metadata check via HEAD request (returns contentLength + ETag)
+            val metadata = s3ResponseStreamer.getObjectMetadata(s3Key)
+            if (metadata == null) {
                 writeErrorResponse(output, 502, "Failed to retrieve S3 object metadata: $bodyFileName")
                 return@runBlocking
             }
-            if (contentLength > MAX_RESPONSE_SIZE_BYTES) {
+            if (metadata.contentLength > MAX_RESPONSE_SIZE_BYTES) {
                 writeErrorResponse(output, 502, "Response payload exceeds the maximum supported streaming limit of 200MB")
                 return@runBlocking
             }
 
-            // Write metadata + delimiter before streaming body
+            // Build headers, replacing Content-Length with the actual S3 object size
             val headers = response.headers
                 ?.flatMap { (name, values) -> values.map { name to it } }
                 ?.toMap()
-                ?: emptyMap()
+                ?.toMutableMap()
+                ?: mutableMapOf()
+            headers.keys.removeAll { it.equals("Content-Length", ignoreCase = true) }
+            headers["Content-Length"] = metadata.contentLength.toString()
+
+            // Write metadata + delimiter before streaming body
             protocolWriter.writeMetadataAndDelimiter(response.statusCode.value, headers, output)
 
             // Stream from S3 with chunked delays using consumer callback
-            // The InputStream is only valid inside the S3 callback scope
-            val success = s3ResponseStreamer.streamWithConsumer(s3Key) { inputStream, _ ->
+            // Pass ETag to ensure we stream the same object version we validated
+            val success = s3ResponseStreamer.streamWithConsumer(s3Key, expectedETag = metadata.eTag) { inputStream, _ ->
                 chunkedWriter.writeChunkedFromStream(
                     input = inputStream,
-                    bodySize = contentLength,
+                    bodySize = metadata.contentLength,
                     numberOfChunks = config.numberOfChunks,
                     totalDurationMs = config.totalDurationMs,
                     output = output,

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriter.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriter.kt
@@ -2,6 +2,7 @@ package nl.vintik.mocknest.infra.aws.runtime.streaming
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.delay
+import java.io.InputStream
 import java.io.OutputStream
 
 private val logger = KotlinLogging.logger {}
@@ -16,6 +17,7 @@ class ChunkedResponseWriter {
 
     companion object {
         private const val IDLE_TIMEOUT_WARNING_THRESHOLD_MS = 270_000L
+        const val STREAM_BUFFER_SIZE = 1024 * 1024 // 1MB
     }
 
     /**
@@ -85,5 +87,77 @@ class ChunkedResponseWriter {
                 baseChunkSize
             }
         }
+    }
+
+    /**
+     * Streams from an InputStream in bounded chunks with delays.
+     * Reads at most [STREAM_BUFFER_SIZE] (1MB) at a time, writes to output,
+     * then delays before the next chunk.
+     *
+     * @param input The InputStream to read from (e.g., S3 object stream)
+     * @param bodySize Total size of the body in bytes (from S3 HEAD)
+     * @param numberOfChunks Number of chunks to deliver
+     * @param totalDurationMs Total delay distributed between chunks
+     * @param output The OutputStream to write chunks to
+     */
+    suspend fun writeChunkedFromStream(
+        input: InputStream,
+        bodySize: Long,
+        numberOfChunks: Int,
+        totalDurationMs: Long,
+        output: OutputStream,
+    ) {
+        if (totalDurationMs > IDLE_TIMEOUT_WARNING_THRESHOLD_MS) {
+            logger.warn {
+                "Chunked dribble delay totalDuration ${totalDurationMs}ms exceeds ${IDLE_TIMEOUT_WARNING_THRESHOLD_MS}ms. " +
+                    "This may exceed the 5-minute streaming idle timeout."
+            }
+        }
+
+        val chunkSize = calculateStreamChunkSize(bodySize, numberOfChunks)
+        val delayBetweenChunks = totalDurationMs / numberOfChunks
+        val buffer = ByteArray(minOf(chunkSize.toInt(), STREAM_BUFFER_SIZE))
+
+        var totalBytesWritten = 0L
+        var chunkIndex = 0
+
+        while (totalBytesWritten < bodySize) {
+            if (chunkIndex > 0 && delayBetweenChunks > 0) {
+                delay(delayBetweenChunks)
+            }
+
+            var chunkBytesWritten = 0L
+            val targetChunkBytes = chunkSize
+
+            while (chunkBytesWritten < targetChunkBytes) {
+                val toRead = minOf(
+                    buffer.size.toLong(),
+                    targetChunkBytes - chunkBytesWritten,
+                    bodySize - totalBytesWritten
+                ).toInt()
+                if (toRead <= 0) break
+
+                val bytesRead = input.read(buffer, 0, toRead)
+                if (bytesRead == -1) break
+
+                output.write(buffer, 0, bytesRead)
+                chunkBytesWritten += bytesRead
+                totalBytesWritten += bytesRead
+            }
+            output.flush()
+            chunkIndex++
+        }
+    }
+
+    /**
+     * Calculates the target chunk size for stream-based chunking using ceiling division.
+     *
+     * @param bodySize Total body size in bytes
+     * @param numberOfChunks Number of chunks to divide into
+     * @return Target chunk size in bytes, or 0 if bodySize is 0 or numberOfChunks <= 0
+     */
+    internal fun calculateStreamChunkSize(bodySize: Long, numberOfChunks: Int): Long {
+        if (bodySize == 0L || numberOfChunks <= 0) return 0L
+        return (bodySize + numberOfChunks - 1) / numberOfChunks // ceiling division
     }
 }

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriter.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriter.kt
@@ -8,6 +8,12 @@ import java.io.OutputStream
 private val logger = KotlinLogging.logger {}
 
 /**
+ * Thrown when the InputStream ends before the expected number of bytes have been read.
+ * This prevents infinite loops when bodySize is larger than the actual stream content.
+ */
+class PrematureEofException(message: String) : java.io.IOException(message)
+
+/**
  * Splits a response body into chunks with delays between writes,
  * simulating Server-Sent Events streaming behavior.
  *
@@ -116,7 +122,8 @@ class ChunkedResponseWriter {
 
         val chunkSize = calculateStreamChunkSize(bodySize, numberOfChunks)
         val delayBetweenChunks = totalDurationMs / numberOfChunks
-        val buffer = ByteArray(minOf(chunkSize.toInt(), STREAM_BUFFER_SIZE))
+        val bufferSize = minOf(chunkSize, STREAM_BUFFER_SIZE.toLong()).toInt()
+        val buffer = ByteArray(bufferSize)
 
         var totalBytesWritten = 0L
         var chunkIndex = 0
@@ -138,7 +145,11 @@ class ChunkedResponseWriter {
                 if (toRead <= 0) break
 
                 val bytesRead = input.read(buffer, 0, toRead)
-                if (bytesRead == -1) break
+                if (bytesRead == -1) {
+                    throw PrematureEofException(
+                        "InputStream ended prematurely: expected $bodySize bytes but only received $totalBytesWritten bytes"
+                    )
+                }
 
                 output.write(buffer, 0, bytesRead)
                 chunkBytesWritten += bytesRead

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt
@@ -30,6 +30,36 @@ class S3ResponseStreamer(
     }
 
     /**
+     * Metadata about an S3 object retrieved via HeadObject.
+     *
+     * @param contentLength Size of the object in bytes
+     * @param eTag Entity tag identifying the specific version of the object
+     */
+    data class ObjectMetadata(val contentLength: Long, val eTag: String)
+
+    /**
+     * Gets metadata (content length and ETag) of an S3 object without downloading it.
+     * Uses HeadObject to retrieve metadata only.
+     *
+     * @param s3Key The S3 object key
+     * @return Object metadata, or null if the object doesn't exist or an error occurs
+     */
+    suspend fun getObjectMetadata(s3Key: String): ObjectMetadata? =
+        runCatching {
+            val response = s3Client.headObject(HeadObjectRequest {
+                bucket = bucketName
+                key = s3Key
+            })
+            val length = response.contentLength ?: return@runCatching null
+            val etag = response.eTag ?: return@runCatching null
+            ObjectMetadata(length, etag)
+        }.onFailure { exception ->
+            logger.error(exception) {
+                "Failed to get metadata for S3 object: key=$s3Key, bucket=$bucketName"
+            }
+        }.getOrNull()
+
+    /**
      * Gets the content length of an S3 object without downloading it.
      * Uses HeadObject to retrieve metadata only.
      *
@@ -92,18 +122,24 @@ class S3ResponseStreamer(
      * the Kotlin AWS SDK's getObject callback scope.
      *
      * @param s3Key The S3 object key
+     * @param expectedETag If provided, the request uses If-Match to ensure the object
+     *                     has not been replaced since the HEAD request. A mismatch
+     *                     causes S3 to return 412 Precondition Failed, which is caught
+     *                     and returns false.
      * @param consumer Callback that receives the InputStream and content length.
      *                 Must consume the stream before returning.
      * @return true if streaming completed successfully, false on error
      */
     suspend fun streamWithConsumer(
         s3Key: String,
+        expectedETag: String? = null,
         consumer: suspend (inputStream: InputStream, contentLength: Long) -> Unit,
     ): Boolean =
         runCatching {
             s3Client.getObject(GetObjectRequest {
                 bucket = bucketName
                 key = s3Key
+                ifMatch = expectedETag
             }) { response ->
                 val body = response.body
                     ?: throw S3StreamingException("S3 object body is null for key: $s3Key")

--- a/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt
+++ b/software/infra/aws/runtime/src/main/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamer.kt
@@ -2,9 +2,11 @@ package nl.vintik.mocknest.infra.aws.runtime.streaming
 
 import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.GetObjectRequest
+import aws.sdk.kotlin.services.s3.model.HeadObjectRequest
 import aws.smithy.kotlin.runtime.content.toInputStream
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
+import java.io.InputStream
 import java.io.OutputStream
 
 private val logger = KotlinLogging.logger {}
@@ -26,6 +28,25 @@ class S3ResponseStreamer(
         /** Maximum buffer size for streaming S3 content: 1MB */
         const val BUFFER_SIZE = 1024 * 1024
     }
+
+    /**
+     * Gets the content length of an S3 object without downloading it.
+     * Uses HeadObject to retrieve metadata only.
+     *
+     * @param s3Key The S3 object key
+     * @return Content length in bytes, or null if the object doesn't exist or an error occurs
+     */
+    suspend fun getContentLength(s3Key: String): Long? =
+        runCatching {
+            s3Client.headObject(HeadObjectRequest {
+                bucket = bucketName
+                key = s3Key
+            }).contentLength
+        }.onFailure { exception ->
+            logger.error(exception) {
+                "Failed to get content length for S3 object: key=$s3Key, bucket=$bucketName"
+            }
+        }.getOrNull()
 
     /**
      * Streams the content of an S3 object identified by [s3Key] directly to [output]
@@ -59,6 +80,41 @@ class S3ResponseStreamer(
         }.onFailure { exception ->
             logger.error(exception) {
                 "Failed to stream S3 object: key=$s3Key, bucket=$bucketName, reason=${exception.message}"
+            }
+        }.getOrDefault(false)
+
+    /**
+     * Streams S3 object content through a consumer callback, keeping the getObject
+     * lifecycle contained within this method. The consumer receives the InputStream
+     * and content length, and must consume the stream before returning.
+     *
+     * This design avoids returning an InputStream that would be invalid outside
+     * the Kotlin AWS SDK's getObject callback scope.
+     *
+     * @param s3Key The S3 object key
+     * @param consumer Callback that receives the InputStream and content length.
+     *                 Must consume the stream before returning.
+     * @return true if streaming completed successfully, false on error
+     */
+    suspend fun streamWithConsumer(
+        s3Key: String,
+        consumer: suspend (inputStream: InputStream, contentLength: Long) -> Unit,
+    ): Boolean =
+        runCatching {
+            s3Client.getObject(GetObjectRequest {
+                bucket = bucketName
+                key = s3Key
+            }) { response ->
+                val body = response.body
+                    ?: throw S3StreamingException("S3 object body is null for key: $s3Key")
+                val contentLength = response.contentLength ?: 0L
+                val inputStream = body.toInputStream()
+                consumer(inputStream, contentLength)
+            }
+            true
+        }.onFailure { exception ->
+            logger.error(exception) {
+                "Failed to stream S3 object with consumer: key=$s3Key, bucket=$bucketName"
             }
         }.getOrDefault(false)
 }

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt
@@ -59,7 +59,8 @@ import java.util.stream.Stream
  */
 @Isolated
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@Tag("Feature: zero-memory-streaming, Property 4: Handler routes to S3 streaming when bodyFileName is present")
+@Tag("Feature-zero-memory-streaming")
+@Tag("Property-4-Handler-routes-to-S3-streaming-when-bodyFileName-is-present")
 class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
 
     private val mockHandleClientRequest: HandleClientRequest = mockk(relaxed = true)
@@ -119,13 +120,13 @@ class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
      * **Validates: Requirements 2.1, 2.2**
      *
      * For any CapturedDribbleConfig containing a non-null bodyFileName, the handler SHALL:
-     * 1. Call S3ResponseStreamer.getContentLength with the correct S3 key (__files/{bodyFileName})
-     * 2. Call S3ResponseStreamer.streamWithConsumer with the correct S3 key
+     * 1. Call S3ResponseStreamer.getObjectMetadata with the correct S3 key (__files/{bodyFileName})
+     * 2. Call S3ResponseStreamer.streamWithConsumer with the correct S3 key and ETag
      * 3. Write metadata+delimiter before the body content in the output
      */
     @ParameterizedTest(name = "Property 4: bodyFileName={0}, chunks={1}, durationMs={2}")
     @MethodSource("s3RoutingTestCases")
-    @Tag("Feature: zero-memory-streaming, Property 4: Handler routes to S3 streaming when bodyFileName is present")
+    @Tag("Property-4-Handler-routes-to-S3-streaming-when-bodyFileName-is-present")
     fun `Given CapturedDribbleConfig with bodyFileName When handling client request Then routes to S3 streaming with metadata before body`(
         bodyFileName: String,
         numberOfChunks: Int,
@@ -154,11 +155,14 @@ class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
             clientResponse
         }
 
-        coEvery { mockS3ResponseStreamer.getContentLength(s3Key) } returns bodyBytes.size.toLong()
+        coEvery { mockS3ResponseStreamer.getObjectMetadata(s3Key) } returns S3ResponseStreamer.ObjectMetadata(
+            contentLength = bodyBytes.size.toLong(),
+            eTag = "\"test-etag-$bodyFileName\"",
+        )
         coEvery {
-            mockS3ResponseStreamer.streamWithConsumer(s3Key, any())
+            mockS3ResponseStreamer.streamWithConsumer(s3Key, any(), any())
         } coAnswers {
-            val consumer = secondArg<suspend (InputStream, Long) -> Unit>()
+            val consumer = thirdArg<suspend (InputStream, Long) -> Unit>()
             consumer(ByteArrayInputStream(bodyBytes), bodyBytes.size.toLong())
             true
         }
@@ -167,8 +171,8 @@ class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
         handler.handleRequest(input, output, mockContext)
 
         // Then — S3ResponseStreamer is called with correct S3 key
-        coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength(s3Key) }
-        coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer(s3Key, any()) }
+        coVerify(exactly = 1) { mockS3ResponseStreamer.getObjectMetadata(s3Key) }
+        coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer(s3Key, any(), any()) }
 
         // Then — output contains metadata+delimiter before body content
         val bytes = output.toByteArray()

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt
@@ -159,8 +159,9 @@ class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
             contentLength = bodyBytes.size.toLong(),
             eTag = "\"test-etag-$bodyFileName\"",
         )
+        val expectedETag = "\"test-etag-$bodyFileName\""
         coEvery {
-            mockS3ResponseStreamer.streamWithConsumer(s3Key, any(), any())
+            mockS3ResponseStreamer.streamWithConsumer(s3Key, expectedETag, any())
         } coAnswers {
             val consumer = thirdArg<suspend (InputStream, Long) -> Unit>()
             consumer(ByteArrayInputStream(bodyBytes), bodyBytes.size.toLong())
@@ -170,9 +171,9 @@ class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
         // When
         handler.handleRequest(input, output, mockContext)
 
-        // Then — S3ResponseStreamer is called with correct S3 key
+        // Then — S3ResponseStreamer is called with correct S3 key and exact ETag
         coVerify(exactly = 1) { mockS3ResponseStreamer.getObjectMetadata(s3Key) }
-        coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer(s3Key, any(), any()) }
+        coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer(s3Key, expectedETag, any()) }
 
         // Then — output contains metadata+delimiter before body content
         val bytes = output.toByteArray()

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerPropertyTest.kt
@@ -1,0 +1,262 @@
+package nl.vintik.mocknest.infra.aws.runtime.function
+
+import com.amazonaws.services.lambda.runtime.Context
+import com.github.tomakehurst.wiremock.WireMockServer
+import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import nl.vintik.mocknest.application.runtime.extensions.CapturedDribbleConfig
+import nl.vintik.mocknest.application.runtime.extensions.ChunkedDribbleDelayCapture
+import nl.vintik.mocknest.application.runtime.usecases.GetRuntimeHealth
+import nl.vintik.mocknest.application.runtime.usecases.HandleAdminRequest
+import nl.vintik.mocknest.application.runtime.usecases.HandleClientRequest
+import nl.vintik.mocknest.domain.core.HttpResponse
+import nl.vintik.mocknest.domain.core.HttpStatusCode
+import nl.vintik.mocknest.infra.aws.core.di.KoinBootstrap
+import nl.vintik.mocknest.infra.aws.core.streaming.StreamingProtocolWriter
+import nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimeMappingReloadHook
+import nl.vintik.mocknest.infra.aws.runtime.snapstart.RuntimePrimingHook
+import nl.vintik.mocknest.infra.aws.runtime.streaming.S3ResponseStreamer
+import org.crac.Core
+import org.crac.Resource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.parallel.Isolated
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.util.stream.Stream
+
+/**
+ * Property-based tests for [StreamingRuntimeLambdaHandler] S3 routing behavior.
+ *
+ * **Property 4: Handler routes to S3 streaming when bodyFileName is present**
+ *
+ * For any CapturedDribbleConfig containing a non-null bodyFileName, the handler SHALL
+ * use the S3ResponseStreamer to stream the response body rather than using the in-memory
+ * body bytes, and SHALL write metadata+delimiter before the chunked body content.
+ *
+ * **Validates: Requirements 2.1, 2.2**
+ */
+@Isolated
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Tag("Feature: zero-memory-streaming, Property 4: Handler routes to S3 streaming when bodyFileName is present")
+class StreamingRuntimeLambdaHandlerPropertyTest : KoinTest {
+
+    private val mockHandleClientRequest: HandleClientRequest = mockk(relaxed = true)
+    private val mockHandleAdminRequest: HandleAdminRequest = mockk(relaxed = true)
+    private val mockGetRuntimeHealth: GetRuntimeHealth = mockk(relaxed = true)
+    private val mockWireMockServer: WireMockServer = mockk(relaxed = true)
+    private val mockS3ResponseStreamer: S3ResponseStreamer = mockk(relaxed = true)
+    private val mockPrimingHook: RuntimePrimingHook = mockk(relaxed = true)
+    private val mockReloadHook: RuntimeMappingReloadHook = mockk(relaxed = true)
+    private val mockContext: Context = mockk(relaxed = true)
+
+    private lateinit var handler: StreamingRuntimeLambdaHandler
+
+    @BeforeAll
+    fun setUp() {
+        mockkStatic(Core::class)
+        val mockCracContext: org.crac.Context<Resource> = mockk(relaxed = true)
+        every { Core.getGlobalContext() } returns mockCracContext
+
+        KoinBootstrap.init(listOf(module {
+            single<HandleClientRequest> { mockHandleClientRequest }
+            single<HandleAdminRequest> { mockHandleAdminRequest }
+            single<GetRuntimeHealth> { mockGetRuntimeHealth }
+            single<WireMockServer> { mockWireMockServer }
+            single { mockS3ResponseStreamer }
+            single { mockPrimingHook }
+            single { mockReloadHook }
+        }))
+        handler = StreamingRuntimeLambdaHandler()
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        stopKoin()
+        KoinBootstrap.reset()
+        unmockkAll()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        clearMocks(
+            mockHandleClientRequest,
+            mockHandleAdminRequest,
+            mockGetRuntimeHealth,
+            mockWireMockServer,
+            mockS3ResponseStreamer,
+        )
+        ChunkedDribbleDelayCapture.clear()
+    }
+
+    // =========================================================================
+    // Property 4: Handler routes to S3 streaming when bodyFileName is present
+    // Validates: Requirements 2.1, 2.2
+    // =========================================================================
+
+    /**
+     * **Validates: Requirements 2.1, 2.2**
+     *
+     * For any CapturedDribbleConfig containing a non-null bodyFileName, the handler SHALL:
+     * 1. Call S3ResponseStreamer.getContentLength with the correct S3 key (__files/{bodyFileName})
+     * 2. Call S3ResponseStreamer.streamWithConsumer with the correct S3 key
+     * 3. Write metadata+delimiter before the body content in the output
+     */
+    @ParameterizedTest(name = "Property 4: bodyFileName={0}, chunks={1}, durationMs={2}")
+    @MethodSource("s3RoutingTestCases")
+    @Tag("Feature: zero-memory-streaming, Property 4: Handler routes to S3 streaming when bodyFileName is present")
+    fun `Given CapturedDribbleConfig with bodyFileName When handling client request Then routes to S3 streaming with metadata before body`(
+        bodyFileName: String,
+        numberOfChunks: Int,
+        totalDurationMs: Long,
+    ) {
+        // Given
+        val input = createApiGatewayRequest("/mocknest/api/resource", "GET")
+        val output = ByteArrayOutputStream()
+        val s3Key = "__files/$bodyFileName"
+        val bodyContent = "s3-body-content-for-$bodyFileName"
+        val bodyBytes = bodyContent.toByteArray(Charsets.UTF_8)
+        val clientResponse = HttpResponse(
+            HttpStatusCode.OK,
+            mapOf("Content-Type" to listOf("application/json")),
+            "", // empty body because transformer intercepted bodyFileName
+        )
+
+        every { mockHandleClientRequest.invoke(any()) } answers {
+            ChunkedDribbleDelayCapture.setForTest(
+                CapturedDribbleConfig(
+                    numberOfChunks = numberOfChunks,
+                    totalDurationMs = totalDurationMs,
+                    bodyFileName = bodyFileName,
+                )
+            )
+            clientResponse
+        }
+
+        coEvery { mockS3ResponseStreamer.getContentLength(s3Key) } returns bodyBytes.size.toLong()
+        coEvery {
+            mockS3ResponseStreamer.streamWithConsumer(s3Key, any())
+        } coAnswers {
+            val consumer = secondArg<suspend (InputStream, Long) -> Unit>()
+            consumer(ByteArrayInputStream(bodyBytes), bodyBytes.size.toLong())
+            true
+        }
+
+        // When
+        handler.handleRequest(input, output, mockContext)
+
+        // Then — S3ResponseStreamer is called with correct S3 key
+        coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength(s3Key) }
+        coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer(s3Key, any()) }
+
+        // Then — output contains metadata+delimiter before body content
+        val bytes = output.toByteArray()
+        val delimiterIndex = findNullDelimiterIndex(bytes)
+        assertTrue(delimiterIndex > 0) {
+            "Expected null byte delimiter in streaming response for bodyFileName=$bodyFileName"
+        }
+
+        // Verify metadata contains correct status code
+        val metadataJson = String(bytes, 0, delimiterIndex, Charsets.UTF_8)
+        val metadata = Json.parseToJsonElement(metadataJson).jsonObject
+        assertEquals(200, metadata["statusCode"]?.jsonPrimitive?.int) {
+            "Expected statusCode 200 in metadata for bodyFileName=$bodyFileName"
+        }
+
+        // Verify body content follows after delimiter
+        val bodyStart = delimiterIndex + StreamingProtocolWriter.NULL_DELIMITER_SIZE
+        val outputBody = String(bytes, bodyStart, bytes.size - bodyStart, Charsets.UTF_8)
+        assertEquals(bodyContent, outputBody) {
+            "Expected S3 body content after delimiter for bodyFileName=$bodyFileName"
+        }
+    }
+
+    // =========================================================================
+    // Helper methods
+    // =========================================================================
+
+    /**
+     * Creates a valid API Gateway proxy request JSON as an InputStream.
+     */
+    private fun createApiGatewayRequest(
+        path: String,
+        httpMethod: String,
+    ): ByteArrayInputStream {
+        val json = """{
+            "httpMethod": "$httpMethod",
+            "path": "$path",
+            "headers": {"Accept": "application/json"},
+            "queryStringParameters": {},
+            "body": null,
+            "isBase64Encoded": false
+        }"""
+        return ByteArrayInputStream(json.toByteArray(Charsets.UTF_8))
+    }
+
+    /**
+     * Finds the index of the 8 null byte delimiter in the streaming response bytes.
+     */
+    private fun findNullDelimiterIndex(bytes: ByteArray): Int {
+        val size = StreamingProtocolWriter.NULL_DELIMITER_SIZE
+        for (i in 0..bytes.size - size) {
+            var allNull = true
+            for (k in 0 until size) {
+                if (bytes[i + k] != 0.toByte()) {
+                    allNull = false
+                    break
+                }
+            }
+            if (allNull) return i
+        }
+        return -1
+    }
+
+    // =========================================================================
+    // Test data provider
+    // =========================================================================
+
+    companion object {
+
+        @JvmStatic
+        fun s3RoutingTestCases(): Stream<Arguments> = Stream.of(
+            // Various bodyFileName values with diverse dribble configs
+            // totalDurationMs kept small to avoid test timeouts (routing is the property under test)
+            Arguments.of("large-response.json", 5, 0L),
+            Arguments.of("payload.xml", 10, 0L),
+            Arguments.of("binary-data.bin", 2, 50L),
+            Arguments.of("nested/path/response.json", 3, 30L),
+            Arguments.of("huge-payload.dat", 100, 0L),
+            Arguments.of("response-with-spaces in name.json", 4, 40L),
+            Arguments.of("unicode-файл.json", 5, 0L),
+            Arguments.of("a.txt", 2, 20L),
+            Arguments.of("deep/nested/dir/file.json", 7, 0L),
+            Arguments.of("error-response.xml", 3, 30L),
+            Arguments.of("image.png", 20, 0L),
+            Arguments.of("very-long-filename-that-represents-a-complex-api-response-body.json", 5, 0L),
+            Arguments.of("data.csv", 15, 0L),
+            Arguments.of("minimal.txt", 2, 0L),
+            Arguments.of("response.html", 8, 0L),
+        )
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerTest.kt
@@ -6,6 +6,8 @@ import com.github.tomakehurst.wiremock.http.ChunkedDribbleDelay
 import com.github.tomakehurst.wiremock.http.ResponseDefinition
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent
 import io.mockk.clearMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
@@ -44,6 +46,7 @@ import org.koin.dsl.module
 import org.koin.test.KoinTest
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.InputStream
 import java.io.OutputStream
 
 /**
@@ -545,6 +548,228 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
                 bytes.size,
             )
             assertEquals(0, bodyBytes.size, "Body should be empty for null body response")
+        }
+    }
+
+    @Nested
+    inner class S3ChunkedStreamingPath {
+
+        @Test
+        fun `Given CapturedDribbleConfig with bodyFileName When handling client request Then calls S3ResponseStreamer and writes chunked response`() {
+            // Given
+            val input = createApiGatewayRequest("/mocknest/api/large-file", "GET")
+            val output = ByteArrayOutputStream()
+            val bodyContent = "streamed-body-content-from-s3"
+            val clientResponse = HttpResponse(
+                HttpStatusCode.OK,
+                mapOf("Content-Type" to listOf("application/json")),
+                "", // empty body because transformer intercepted bodyFileName
+            )
+            // Mock handleClientRequest to set the thread-local (simulating transformer behavior)
+            every { mockHandleClientRequest.invoke(any()) } answers {
+                ChunkedDribbleDelayCapture.setForTest(
+                    CapturedDribbleConfig(numberOfChunks = 3, totalDurationMs = 300, bodyFileName = "large-response.json")
+                )
+                clientResponse
+            }
+
+            // Mock S3ResponseStreamer to return valid content length and stream content
+            coEvery { mockS3ResponseStreamer.getContentLength("__files/large-response.json") } returns bodyContent.length.toLong()
+            coEvery {
+                mockS3ResponseStreamer.streamWithConsumer("__files/large-response.json", any())
+            } coAnswers {
+                val consumer = secondArg<suspend (InputStream, Long) -> Unit>()
+                consumer(ByteArrayInputStream(bodyContent.toByteArray()), bodyContent.length.toLong())
+                true
+            }
+
+            // When
+            handler.handleRequest(input, output, mockContext)
+
+            // Then
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/large-response.json") }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer("__files/large-response.json", any()) }
+
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(bodyContent, parsed.body)
+        }
+
+        @Test
+        fun `Given getContentLength returns null When handling S3 streaming request Then writes 502 error`() {
+            // Given
+            val input = createApiGatewayRequest("/mocknest/api/missing-file", "GET")
+            val output = ByteArrayOutputStream()
+            val clientResponse = HttpResponse(
+                HttpStatusCode.OK,
+                mapOf("Content-Type" to listOf("application/json")),
+                "",
+            )
+            // Mock handleClientRequest to set the thread-local (simulating transformer behavior)
+            every { mockHandleClientRequest.invoke(any()) } answers {
+                ChunkedDribbleDelayCapture.setForTest(
+                    CapturedDribbleConfig(numberOfChunks = 3, totalDurationMs = 300, bodyFileName = "missing-file.json")
+                )
+                clientResponse
+            }
+
+            // Mock S3ResponseStreamer to return null content length (object not found)
+            coEvery { mockS3ResponseStreamer.getContentLength("__files/missing-file.json") } returns null
+
+            // When
+            handler.handleRequest(input, output, mockContext)
+
+            // Then
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/missing-file.json") }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any()) }
+
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(502, parsed.statusCode)
+            assertTrue(parsed.body.contains("Failed to retrieve S3 object metadata"))
+            assertTrue(parsed.body.contains("missing-file.json"))
+        }
+
+        @Test
+        fun `Given content length exceeds 200MB When handling S3 streaming request Then writes 502 error`() {
+            // Given
+            val input = createApiGatewayRequest("/mocknest/api/huge-file", "GET")
+            val output = ByteArrayOutputStream()
+            val clientResponse = HttpResponse(
+                HttpStatusCode.OK,
+                mapOf("Content-Type" to listOf("application/json")),
+                "",
+            )
+            // Mock handleClientRequest to set the thread-local (simulating transformer behavior)
+            every { mockHandleClientRequest.invoke(any()) } answers {
+                ChunkedDribbleDelayCapture.setForTest(
+                    CapturedDribbleConfig(numberOfChunks = 5, totalDurationMs = 5000, bodyFileName = "huge-file.bin")
+                )
+                clientResponse
+            }
+
+            // Mock S3ResponseStreamer to return content length exceeding 200MB
+            val oversizedLength = 200L * 1024 * 1024 + 1 // 200MB + 1 byte
+            coEvery { mockS3ResponseStreamer.getContentLength("__files/huge-file.bin") } returns oversizedLength
+
+            // When
+            handler.handleRequest(input, output, mockContext)
+
+            // Then
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/huge-file.bin") }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any()) }
+
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(502, parsed.statusCode)
+            assertTrue(parsed.body.contains("200MB"))
+        }
+
+        @Test
+        fun `Given streamWithConsumer returns false When handling S3 streaming request Then metadata already written and error logged`() {
+            // Given
+            val input = createApiGatewayRequest("/mocknest/api/stream-fail", "GET")
+            val output = ByteArrayOutputStream()
+            val clientResponse = HttpResponse(
+                HttpStatusCode.OK,
+                mapOf("Content-Type" to listOf("text/plain")),
+                "",
+            )
+            // Mock handleClientRequest to set the thread-local (simulating transformer behavior)
+            every { mockHandleClientRequest.invoke(any()) } answers {
+                ChunkedDribbleDelayCapture.setForTest(
+                    CapturedDribbleConfig(numberOfChunks = 3, totalDurationMs = 300, bodyFileName = "stream-fail.json")
+                )
+                clientResponse
+            }
+
+            // Mock S3ResponseStreamer: content length OK but streaming fails
+            coEvery { mockS3ResponseStreamer.getContentLength("__files/stream-fail.json") } returns 1024L
+            coEvery { mockS3ResponseStreamer.streamWithConsumer("__files/stream-fail.json", any()) } returns false
+
+            // When
+            handler.handleRequest(input, output, mockContext)
+
+            // Then — metadata+delimiter already written, can't change status code
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/stream-fail.json") }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer("__files/stream-fail.json", any()) }
+
+            // The response should have metadata written (200 status from the original response)
+            // but no body content since streaming failed
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            // Body should be empty since streamWithConsumer returned false without writing
+            assertEquals("", parsed.body)
+        }
+
+        @Test
+        fun `Given CapturedDribbleConfig without bodyFileName When handling client request Then uses existing ByteArray path without S3 calls`() {
+            // Given
+            val input = createApiGatewayRequest("/mocknest/api/inline-body", "GET")
+            val output = ByteArrayOutputStream()
+            val inlineBody = "inline response body content"
+            val clientResponse = HttpResponse(
+                HttpStatusCode.OK,
+                mapOf("Content-Type" to listOf("text/plain")),
+                inlineBody,
+            )
+            // Mock handleClientRequest to set the thread-local WITHOUT bodyFileName (inline path)
+            every { mockHandleClientRequest.invoke(any()) } answers {
+                ChunkedDribbleDelayCapture.setForTest(
+                    CapturedDribbleConfig(numberOfChunks = 2, totalDurationMs = 200, bodyFileName = null)
+                )
+                clientResponse
+            }
+
+            // When
+            handler.handleRequest(input, output, mockContext)
+
+            // Then — S3ResponseStreamer should NOT be called
+            coVerify(exactly = 0) { mockS3ResponseStreamer.getContentLength(any()) }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any()) }
+
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(inlineBody, parsed.body)
+        }
+
+        @Test
+        fun `Given bodyFileName intercepted by transformer When response body is empty placeholder Then proves WireMock did not load the file`() {
+            // Given — simulates the transformer having intercepted bodyFileName,
+            // so WireMock returns an empty body (the transformer cleared it)
+            val input = createApiGatewayRequest("/mocknest/api/intercepted", "GET")
+            val output = ByteArrayOutputStream()
+            val s3Content = "actual-s3-file-content-that-was-not-loaded-by-wiremock"
+            val clientResponse = HttpResponse(
+                HttpStatusCode.OK,
+                mapOf("Content-Type" to listOf("application/json")),
+                "", // empty body — proves WireMock didn't load the file
+            )
+            // Mock handleClientRequest to set the thread-local with bodyFileName (simulating transformer)
+            every { mockHandleClientRequest.invoke(any()) } answers {
+                ChunkedDribbleDelayCapture.setForTest(
+                    CapturedDribbleConfig(numberOfChunks = 2, totalDurationMs = 100, bodyFileName = "intercepted-file.json")
+                )
+                clientResponse
+            }
+
+            coEvery { mockS3ResponseStreamer.getContentLength("__files/intercepted-file.json") } returns s3Content.length.toLong()
+            coEvery {
+                mockS3ResponseStreamer.streamWithConsumer("__files/intercepted-file.json", any())
+            } coAnswers {
+                val consumer = secondArg<suspend (InputStream, Long) -> Unit>()
+                consumer(ByteArrayInputStream(s3Content.toByteArray()), s3Content.length.toLong())
+                true
+            }
+
+            // When
+            handler.handleRequest(input, output, mockContext)
+
+            // Then — the response body comes from S3 streaming, not from WireMock's response.body
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            // Body is the S3 content, proving WireMock's empty body was ignored
+            assertEquals(s3Content, parsed.body)
+            // The original response.body was "" (empty), confirming WireMock didn't load the file
+            assertEquals("", clientResponse.body)
         }
     }
 

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/function/StreamingRuntimeLambdaHandlerTest.kt
@@ -574,11 +574,14 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
             }
 
             // Mock S3ResponseStreamer to return valid content length and stream content
-            coEvery { mockS3ResponseStreamer.getContentLength("__files/large-response.json") } returns bodyContent.length.toLong()
+            coEvery { mockS3ResponseStreamer.getObjectMetadata("__files/large-response.json") } returns S3ResponseStreamer.ObjectMetadata(
+                contentLength = bodyContent.length.toLong(),
+                eTag = "\"etag-large-response\"",
+            )
             coEvery {
-                mockS3ResponseStreamer.streamWithConsumer("__files/large-response.json", any())
+                mockS3ResponseStreamer.streamWithConsumer("__files/large-response.json", any(), any())
             } coAnswers {
-                val consumer = secondArg<suspend (InputStream, Long) -> Unit>()
+                val consumer = thirdArg<suspend (InputStream, Long) -> Unit>()
                 consumer(ByteArrayInputStream(bodyContent.toByteArray()), bodyContent.length.toLong())
                 true
             }
@@ -587,8 +590,8 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
             handler.handleRequest(input, output, mockContext)
 
             // Then
-            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/large-response.json") }
-            coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer("__files/large-response.json", any()) }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getObjectMetadata("__files/large-response.json") }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer("__files/large-response.json", any(), any()) }
 
             val parsed = parseStreamingResponse(output.toByteArray())
             assertEquals(200, parsed.statusCode)
@@ -613,15 +616,15 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
                 clientResponse
             }
 
-            // Mock S3ResponseStreamer to return null content length (object not found)
-            coEvery { mockS3ResponseStreamer.getContentLength("__files/missing-file.json") } returns null
+            // Mock S3ResponseStreamer to return null metadata (object not found)
+            coEvery { mockS3ResponseStreamer.getObjectMetadata("__files/missing-file.json") } returns null
 
             // When
             handler.handleRequest(input, output, mockContext)
 
             // Then
-            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/missing-file.json") }
-            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any()) }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getObjectMetadata("__files/missing-file.json") }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any(), any()) }
 
             val parsed = parseStreamingResponse(output.toByteArray())
             assertEquals(502, parsed.statusCode)
@@ -649,14 +652,17 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
 
             // Mock S3ResponseStreamer to return content length exceeding 200MB
             val oversizedLength = 200L * 1024 * 1024 + 1 // 200MB + 1 byte
-            coEvery { mockS3ResponseStreamer.getContentLength("__files/huge-file.bin") } returns oversizedLength
+            coEvery { mockS3ResponseStreamer.getObjectMetadata("__files/huge-file.bin") } returns S3ResponseStreamer.ObjectMetadata(
+                contentLength = oversizedLength,
+                eTag = "\"etag-huge\"",
+            )
 
             // When
             handler.handleRequest(input, output, mockContext)
 
             // Then
-            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/huge-file.bin") }
-            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any()) }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getObjectMetadata("__files/huge-file.bin") }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any(), any()) }
 
             val parsed = parseStreamingResponse(output.toByteArray())
             assertEquals(502, parsed.statusCode)
@@ -682,15 +688,18 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
             }
 
             // Mock S3ResponseStreamer: content length OK but streaming fails
-            coEvery { mockS3ResponseStreamer.getContentLength("__files/stream-fail.json") } returns 1024L
-            coEvery { mockS3ResponseStreamer.streamWithConsumer("__files/stream-fail.json", any()) } returns false
+            coEvery { mockS3ResponseStreamer.getObjectMetadata("__files/stream-fail.json") } returns S3ResponseStreamer.ObjectMetadata(
+                contentLength = 1024L,
+                eTag = "\"etag-stream-fail\"",
+            )
+            coEvery { mockS3ResponseStreamer.streamWithConsumer("__files/stream-fail.json", any(), any()) } returns false
 
             // When
             handler.handleRequest(input, output, mockContext)
 
             // Then — metadata+delimiter already written, can't change status code
-            coVerify(exactly = 1) { mockS3ResponseStreamer.getContentLength("__files/stream-fail.json") }
-            coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer("__files/stream-fail.json", any()) }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.getObjectMetadata("__files/stream-fail.json") }
+            coVerify(exactly = 1) { mockS3ResponseStreamer.streamWithConsumer("__files/stream-fail.json", any(), any()) }
 
             // The response should have metadata written (200 status from the original response)
             // but no body content since streaming failed
@@ -723,8 +732,8 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
             handler.handleRequest(input, output, mockContext)
 
             // Then — S3ResponseStreamer should NOT be called
-            coVerify(exactly = 0) { mockS3ResponseStreamer.getContentLength(any()) }
-            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any()) }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.getObjectMetadata(any()) }
+            coVerify(exactly = 0) { mockS3ResponseStreamer.streamWithConsumer(any(), any(), any()) }
 
             val parsed = parseStreamingResponse(output.toByteArray())
             assertEquals(200, parsed.statusCode)
@@ -751,11 +760,14 @@ class StreamingRuntimeLambdaHandlerTest : KoinTest {
                 clientResponse
             }
 
-            coEvery { mockS3ResponseStreamer.getContentLength("__files/intercepted-file.json") } returns s3Content.length.toLong()
+            coEvery { mockS3ResponseStreamer.getObjectMetadata("__files/intercepted-file.json") } returns S3ResponseStreamer.ObjectMetadata(
+                contentLength = s3Content.length.toLong(),
+                eTag = "\"etag-intercepted\"",
+            )
             coEvery {
-                mockS3ResponseStreamer.streamWithConsumer("__files/intercepted-file.json", any())
+                mockS3ResponseStreamer.streamWithConsumer("__files/intercepted-file.json", any(), any())
             } coAnswers {
-                val consumer = secondArg<suspend (InputStream, Long) -> Unit>()
+                val consumer = thirdArg<suspend (InputStream, Long) -> Unit>()
                 consumer(ByteArrayInputStream(s3Content.toByteArray()), s3Content.length.toLong())
                 true
             }

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt
@@ -39,7 +39,8 @@ class ChunkedResponseWriterPropertyTest {
      *
      * **Validates: Requirements 3.1, 3.2, 3.3**
      */
-    @Tag("Feature: zero-memory-streaming, Property 6: Bounded memory during InputStream-based streaming")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-6-Bounded-memory-during-InputStream-based-streaming")
     @ParameterizedTest(name = "Property 6: size={0} bytes, chunks={1}")
     @MethodSource("boundedMemoryTestCases")
     fun `Given InputStream of varying size When writeChunkedFromStream Then buffer never exceeds STREAM_BUFFER_SIZE`(
@@ -75,7 +76,8 @@ class ChunkedResponseWriterPropertyTest {
      *
      * **Validates: Requirements 3.1, 3.2, 3.3**
      */
-    @Tag("Feature: zero-memory-streaming, Property 6: Bounded memory during InputStream-based streaming")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-6-Bounded-memory-during-InputStream-based-streaming")
     @ParameterizedTest(name = "Property 6 (large): size={0} bytes, chunks={1}")
     @MethodSource("boundedMemoryLargeTestCases")
     fun `Given large InputStream When writeChunkedFromStream Then buffer never exceeds STREAM_BUFFER_SIZE without full output comparison`(
@@ -116,7 +118,8 @@ class ChunkedResponseWriterPropertyTest {
      *
      * **Validates: Requirements 7.2, 7.4**
      */
-    @Tag("Feature: zero-memory-streaming, Property 7: Streaming round-trip preserves body content byte-for-byte")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-7-Streaming-round-trip-preserves-body-content-byte-for-byte")
     @ParameterizedTest(name = "Property 7: {0}")
     @MethodSource("roundTripTestCases")
     fun `Given random body content When writeChunkedFromStream Then output matches input byte-for-byte`(
@@ -154,7 +157,8 @@ class ChunkedResponseWriterPropertyTest {
      *
      * **Validates: Requirements 7.3**
      */
-    @Tag("Feature: zero-memory-streaming, Property 8: Chunked delivery distributes bytes across configured number of chunks")
+    @Tag("Feature-zero-memory-streaming")
+    @Tag("Property-8-Chunked-delivery-distributes-bytes-across-configured-number-of-chunks")
     @ParameterizedTest(name = "Property 8: {0}")
     @MethodSource("chunkDistributionTestCases")
     fun `Given body size and chunk count When writeChunkedFromStream Then flush count equals numberOfChunks`(

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterPropertyTest.kt
@@ -1,0 +1,378 @@
+package nl.vintik.mocknest.infra.aws.runtime.streaming
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.stream.Stream
+
+/**
+ * Property-based tests for [ChunkedResponseWriter.writeChunkedFromStream].
+ *
+ * Covers:
+ * - Property 6: Bounded memory during InputStream-based streaming
+ * - Property 7: Streaming round-trip preserves body content byte-for-byte
+ * - Property 8: Chunked delivery distributes bytes across configured number of chunks
+ */
+class ChunkedResponseWriterPropertyTest {
+
+    private val writer = ChunkedResponseWriter()
+
+    // ========================================================================
+    // Property 6: Bounded memory during InputStream-based streaming
+    // ========================================================================
+
+    /**
+     * Property 6: Bounded memory during InputStream-based streaming
+     *
+     * For any input stream of size S (where S > 0), the writeChunkedFromStream method
+     * SHALL never hold more than 1MB (1,048,576 bytes) of response body content in memory
+     * at any time, regardless of the total body size or number of chunks configured.
+     *
+     * **Validates: Requirements 3.1, 3.2, 3.3**
+     */
+    @Tag("Feature: zero-memory-streaming, Property 6: Bounded memory during InputStream-based streaming")
+    @ParameterizedTest(name = "Property 6: size={0} bytes, chunks={1}")
+    @MethodSource("boundedMemoryTestCases")
+    fun `Given InputStream of varying size When writeChunkedFromStream Then buffer never exceeds STREAM_BUFFER_SIZE`(
+        size: Int,
+        numberOfChunks: Int,
+    ) = runTest {
+        // Given — create a BoundedReadInputStream that tracks max read size
+        val data = ByteArray(size) { (it % 256).toByte() }
+        val boundedInput = BoundedReadInputStream(ByteArrayInputStream(data))
+        val output = ByteArrayOutputStream()
+
+        // When
+        writer.writeChunkedFromStream(boundedInput, data.size.toLong(), numberOfChunks, 0L, output)
+
+        // Then — no single read request exceeds STREAM_BUFFER_SIZE (1MB)
+        assertTrue(boundedInput.maxReadSize <= ChunkedResponseWriter.STREAM_BUFFER_SIZE) {
+            "Maximum read size was ${boundedInput.maxReadSize} bytes, " +
+                "which exceeds STREAM_BUFFER_SIZE of ${ChunkedResponseWriter.STREAM_BUFFER_SIZE} bytes " +
+                "(input size=$size, numberOfChunks=$numberOfChunks)"
+        }
+
+        // Also verify data integrity: output bytes match input bytes
+        assertArrayEquals(data, output.toByteArray()) {
+            "Output bytes must match input bytes for size=$size, numberOfChunks=$numberOfChunks"
+        }
+    }
+
+    /**
+     * Property 6 (large sizes): Bounded memory during InputStream-based streaming
+     *
+     * For the 50MB test case, uses a ByteCountingOutputStream to avoid OOM in tests
+     * while still verifying the bounded read property.
+     *
+     * **Validates: Requirements 3.1, 3.2, 3.3**
+     */
+    @Tag("Feature: zero-memory-streaming, Property 6: Bounded memory during InputStream-based streaming")
+    @ParameterizedTest(name = "Property 6 (large): size={0} bytes, chunks={1}")
+    @MethodSource("boundedMemoryLargeTestCases")
+    fun `Given large InputStream When writeChunkedFromStream Then buffer never exceeds STREAM_BUFFER_SIZE without full output comparison`(
+        size: Int,
+        numberOfChunks: Int,
+    ) = runTest {
+        // Given — for large sizes, use a counting output to avoid OOM in tests
+        val data = ByteArray(size) { (it % 256).toByte() }
+        val boundedInput = BoundedReadInputStream(ByteArrayInputStream(data))
+        val countingOutput = ByteCountingOutputStream()
+
+        // When
+        writer.writeChunkedFromStream(boundedInput, data.size.toLong(), numberOfChunks, 0L, countingOutput)
+
+        // Then — no single read request exceeds STREAM_BUFFER_SIZE (1MB)
+        assertTrue(boundedInput.maxReadSize <= ChunkedResponseWriter.STREAM_BUFFER_SIZE) {
+            "Maximum read size was ${boundedInput.maxReadSize} bytes, " +
+                "which exceeds STREAM_BUFFER_SIZE of ${ChunkedResponseWriter.STREAM_BUFFER_SIZE} bytes " +
+                "(input size=$size, numberOfChunks=$numberOfChunks)"
+        }
+
+        // Verify total bytes written matches input size (data integrity without storing full output)
+        assertEquals(size.toLong(), countingOutput.totalBytesWritten) {
+            "Total bytes written (${countingOutput.totalBytesWritten}) must equal input size ($size)"
+        }
+    }
+
+    // ========================================================================
+    // Property 7: Streaming round-trip preserves body content byte-for-byte
+    // ========================================================================
+
+    /**
+     * Property 7: Streaming round-trip preserves body content byte-for-byte
+     *
+     * For any body content, streaming it through writeChunkedFromStream with any valid
+     * numberOfChunks and totalDurationMs SHALL produce output that matches the original
+     * content byte-for-byte when all chunks are concatenated.
+     *
+     * **Validates: Requirements 7.2, 7.4**
+     */
+    @Tag("Feature: zero-memory-streaming, Property 7: Streaming round-trip preserves body content byte-for-byte")
+    @ParameterizedTest(name = "Property 7: {0}")
+    @MethodSource("roundTripTestCases")
+    fun `Given random body content When writeChunkedFromStream Then output matches input byte-for-byte`(
+        description: String,
+        bodySize: Int,
+        numberOfChunks: Int,
+    ) = runTest {
+        // Given
+        val data = ByteArray(bodySize) { (it % 256).toByte() }
+        val input = ByteArrayInputStream(data)
+        val output = ByteArrayOutputStream()
+
+        // When
+        writer.writeChunkedFromStream(input, data.size.toLong(), numberOfChunks, 0L, output)
+
+        // Then — output matches input byte-for-byte
+        assertArrayEquals(
+            data,
+            output.toByteArray(),
+            "Streamed output must be byte-identical to original input for: $description"
+        )
+    }
+
+    // ========================================================================
+    // Property 8: Chunked delivery distributes bytes across configured number of chunks
+    // ========================================================================
+
+    /**
+     * Property 8: Chunked delivery distributes bytes across configured number of chunks
+     *
+     * For any body of size S > 0 and configured numberOfChunks N >= 2, the
+     * writeChunkedFromStream method SHALL deliver the body in at most N write-flush
+     * cycles, with each cycle writing approximately S/N bytes (±1 byte for remainder
+     * distribution).
+     *
+     * **Validates: Requirements 7.3**
+     */
+    @Tag("Feature: zero-memory-streaming, Property 8: Chunked delivery distributes bytes across configured number of chunks")
+    @ParameterizedTest(name = "Property 8: {0}")
+    @MethodSource("chunkDistributionTestCases")
+    fun `Given body size and chunk count When writeChunkedFromStream Then flush count equals numberOfChunks`(
+        description: String,
+        bodySize: Int,
+        numberOfChunks: Int,
+    ) = runTest {
+        // Given
+        val data = ByteArray(bodySize) { (it % 256).toByte() }
+        val input = ByteArrayInputStream(data)
+        val flushCountingOutput = FlushCountingOutputStream()
+
+        // When
+        writer.writeChunkedFromStream(input, data.size.toLong(), numberOfChunks, 0L, flushCountingOutput)
+
+        // Then — for normal cases where body >= numberOfChunks, flush count equals numberOfChunks
+        if (bodySize >= numberOfChunks) {
+            assertEquals(
+                numberOfChunks,
+                flushCountingOutput.flushCount,
+                "Flush count must equal numberOfChunks ($numberOfChunks) for: $description"
+            )
+        } else {
+            // Edge case: body smaller than chunk count — flush count may be less than numberOfChunks
+            // because the loop terminates when all bytes are written
+            assertTrue(
+                flushCountingOutput.flushCount <= numberOfChunks,
+                "Flush count (${flushCountingOutput.flushCount}) must be at most numberOfChunks ($numberOfChunks) for: $description"
+            )
+            assertTrue(
+                flushCountingOutput.flushCount >= 1,
+                "Flush count must be at least 1 for non-empty body for: $description"
+            )
+        }
+
+        // Also verify all bytes were written
+        assertEquals(
+            bodySize.toLong(),
+            flushCountingOutput.totalBytesWritten,
+            "Total bytes written must equal body size for: $description"
+        )
+    }
+
+    // ========================================================================
+    // Helper classes
+    // ========================================================================
+
+    /**
+     * Custom InputStream wrapper that tracks the maximum `len` parameter passed to
+     * `read(byte[], int, int)` and asserts that no single read request exceeds
+     * [ChunkedResponseWriter.STREAM_BUFFER_SIZE] (1MB).
+     *
+     * Wraps a [ByteArrayInputStream] and verifies bounded memory usage.
+     */
+    private class BoundedReadInputStream(private val delegate: ByteArrayInputStream) : InputStream() {
+        var maxReadSize = 0
+            private set
+
+        override fun read(): Int = delegate.read()
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (len > maxReadSize) {
+                maxReadSize = len
+            }
+            return delegate.read(b, off, len)
+        }
+
+        override fun available(): Int = delegate.available()
+
+        override fun close() = delegate.close()
+    }
+
+    /**
+     * OutputStream that counts total bytes written without storing them in memory.
+     * Used for large test cases (50MB) to avoid OOM while still verifying data integrity
+     * through byte count comparison.
+     */
+    private class ByteCountingOutputStream : OutputStream() {
+        var totalBytesWritten = 0L
+            private set
+
+        override fun write(b: Int) {
+            totalBytesWritten++
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            totalBytesWritten += len
+        }
+
+        override fun flush() {
+            // no-op
+        }
+    }
+
+    /**
+     * OutputStream that counts flush() calls to verify chunk distribution.
+     */
+    private class FlushCountingOutputStream : OutputStream() {
+        var flushCount = 0
+            private set
+        var totalBytesWritten = 0L
+            private set
+
+        override fun write(b: Int) {
+            totalBytesWritten++
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            totalBytesWritten += len
+        }
+
+        override fun flush() {
+            flushCount++
+        }
+    }
+
+    // ========================================================================
+    // Test data providers
+    // ========================================================================
+
+    companion object {
+
+        @JvmStatic
+        fun boundedMemoryTestCases(): Stream<Arguments> = Stream.of(
+            // 1KB (1024 bytes) with various chunk counts
+            Arguments.of(1024, 2),
+            Arguments.of(1024, 3),
+            Arguments.of(1024, 5),
+            Arguments.of(1024, 10),
+            Arguments.of(1024, 50),
+            Arguments.of(1024, 100),
+            // 100KB with various chunk counts
+            Arguments.of(100 * 1024, 2),
+            Arguments.of(100 * 1024, 3),
+            Arguments.of(100 * 1024, 5),
+            Arguments.of(100 * 1024, 10),
+            Arguments.of(100 * 1024, 50),
+            Arguments.of(100 * 1024, 100),
+            // 1MB (1048576 bytes) with various chunk counts
+            Arguments.of(1048576, 2),
+            Arguments.of(1048576, 3),
+            Arguments.of(1048576, 5),
+            Arguments.of(1048576, 10),
+            Arguments.of(1048576, 50),
+            Arguments.of(1048576, 100),
+            // 5MB with various chunk counts
+            Arguments.of(5 * 1048576, 2),
+            Arguments.of(5 * 1048576, 3),
+            Arguments.of(5 * 1048576, 5),
+            Arguments.of(5 * 1048576, 10),
+            Arguments.of(5 * 1048576, 50),
+            Arguments.of(5 * 1048576, 100),
+            // 10MB with various chunk counts
+            Arguments.of(10 * 1048576, 2),
+            Arguments.of(10 * 1048576, 3),
+            Arguments.of(10 * 1048576, 5),
+            Arguments.of(10 * 1048576, 10),
+            Arguments.of(10 * 1048576, 50),
+            Arguments.of(10 * 1048576, 100),
+        )
+
+        @JvmStatic
+        fun boundedMemoryLargeTestCases(): Stream<Arguments> = Stream.of(
+            // 50MB with various chunk counts — uses ByteCountingOutputStream to avoid OOM
+            Arguments.of(50 * 1048576, 2),
+            Arguments.of(50 * 1048576, 3),
+            Arguments.of(50 * 1048576, 5),
+            Arguments.of(50 * 1048576, 10),
+            Arguments.of(50 * 1048576, 50),
+            Arguments.of(50 * 1048576, 100),
+        )
+
+        @JvmStatic
+        fun roundTripTestCases(): Stream<Arguments> = Stream.of(
+            // Small bodies
+            Arguments.of("1 byte / 2 chunks", 1, 2),
+            Arguments.of("100 bytes / 3 chunks", 100, 3),
+            Arguments.of("1KB / 5 chunks", 1024, 5),
+            // Medium bodies
+            Arguments.of("100KB / 4 chunks", 100 * 1024, 4),
+            Arguments.of("1MB / 2 chunks", 1024 * 1024, 2),
+            Arguments.of("1MB / 10 chunks", 1024 * 1024, 10),
+            // Large bodies
+            Arguments.of("5MB / 5 chunks", 5 * 1024 * 1024, 5),
+            Arguments.of("5MB / 50 chunks", 5 * 1024 * 1024, 50),
+            Arguments.of("10MB / 10 chunks", 10 * 1024 * 1024, 10),
+            // Edge cases
+            Arguments.of("10 bytes / 20 chunks (more chunks than bytes)", 10, 20),
+            Arguments.of("3 bytes / 2 chunks (remainder)", 3, 2),
+            Arguments.of("7 bytes / 3 chunks (remainder)", 7, 3),
+            Arguments.of("1MB + 1 byte / 3 chunks (just over buffer)", 1024 * 1024 + 1, 3),
+            Arguments.of("999 bytes / 13 chunks (prime-ish)", 999, 13),
+            Arguments.of("256 bytes / 256 chunks (1 byte per chunk)", 256, 256),
+        )
+
+        @JvmStatic
+        fun chunkDistributionTestCases(): Stream<Arguments> = Stream.of(
+            // Small body with various chunk counts
+            Arguments.of("100 bytes / 2 chunks", 100, 2),
+            Arguments.of("100 bytes / 3 chunks", 100, 3),
+            Arguments.of("100 bytes / 5 chunks", 100, 5),
+            // Medium body (1MB) with various chunk counts
+            Arguments.of("1MB / 2 chunks", 1024 * 1024, 2),
+            Arguments.of("1MB / 5 chunks", 1024 * 1024, 5),
+            Arguments.of("1MB / 10 chunks", 1024 * 1024, 10),
+            Arguments.of("1MB / 50 chunks", 1024 * 1024, 50),
+            // Large body (5MB) with various chunk counts
+            Arguments.of("5MB / 2 chunks", 5 * 1024 * 1024, 2),
+            Arguments.of("5MB / 5 chunks", 5 * 1024 * 1024, 5),
+            Arguments.of("5MB / 10 chunks", 5 * 1024 * 1024, 10),
+            Arguments.of("5MB / 100 chunks", 5 * 1024 * 1024, 100),
+            // Edge case: body smaller than chunk count
+            Arguments.of("10 bytes / 20 chunks (body < chunks)", 10, 20),
+            // Additional diverse cases
+            Arguments.of("1KB / 7 chunks (remainder)", 1024, 7),
+            Arguments.of("500KB / 3 chunks", 500 * 1024, 3),
+            Arguments.of("2MB / 25 chunks", 2 * 1024 * 1024, 25),
+            Arguments.of("10MB / 100 chunks", 10 * 1024 * 1024, 100),
+        )
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterStreamTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterStreamTest.kt
@@ -1,0 +1,306 @@
+package nl.vintik.mocknest.infra.aws.runtime.streaming
+
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Unit tests for [ChunkedResponseWriter.writeChunkedFromStream] and [ChunkedResponseWriter.calculateStreamChunkSize].
+ *
+ * Tests data integrity across various sizes, bounded memory usage (1MB buffer),
+ * flush behavior (one per chunk), and calculateStreamChunkSize edge cases.
+ *
+ * **Validates: Requirements 3.1, 3.2, 3.3**
+ */
+class ChunkedResponseWriterStreamTest {
+
+    private val writer = ChunkedResponseWriter()
+
+    @Nested
+    inner class DataIntegrity {
+
+        @Test
+        fun `Given 1KB input stream When writeChunkedFromStream Then output matches input byte-for-byte`() = runTest {
+            // Given
+            val data = ByteArray(1024) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 3, 0L, output)
+
+            // Then
+            assertArrayEquals(data, output.toByteArray())
+        }
+
+        @Test
+        fun `Given 5MB input stream When writeChunkedFromStream Then output matches input byte-for-byte`() = runTest {
+            // Given
+            val size = 5 * 1024 * 1024
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 5, 0L, output)
+
+            // Then
+            assertArrayEquals(data, output.toByteArray())
+        }
+
+        @Test
+        fun `Given 10MB input stream When writeChunkedFromStream Then output matches input byte-for-byte`() = runTest {
+            // Given
+            val size = 10 * 1024 * 1024
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 10, 0L, output)
+
+            // Then
+            assertArrayEquals(data, output.toByteArray())
+        }
+
+        @Test
+        fun `Given 1KB input stream with delays When writeChunkedFromStream Then output matches input byte-for-byte`() = runTest {
+            // Given
+            val data = ByteArray(1024) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 4, 1000L, output)
+
+            // Then
+            assertArrayEquals(data, output.toByteArray())
+        }
+    }
+
+    @Nested
+    inner class BoundedMemoryUsage {
+
+        @Test
+        fun `Given 5MB input stream When writeChunkedFromStream Then no single read exceeds 1MB`() = runTest {
+            // Given
+            val size = 5 * 1024 * 1024
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val trackingInput = ReadSizeTrackingInputStream(ByteArrayInputStream(data))
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(trackingInput, data.size.toLong(), 5, 0L, output)
+
+            // Then
+            assertTrue(trackingInput.maxReadSize <= ChunkedResponseWriter.STREAM_BUFFER_SIZE) {
+                "Maximum read size was ${trackingInput.maxReadSize} bytes, " +
+                    "which exceeds STREAM_BUFFER_SIZE of ${ChunkedResponseWriter.STREAM_BUFFER_SIZE} bytes"
+            }
+            // Also verify data integrity
+            assertArrayEquals(data, output.toByteArray())
+        }
+
+        @Test
+        fun `Given 10MB input stream When writeChunkedFromStream Then no single read exceeds 1MB`() = runTest {
+            // Given
+            val size = 10 * 1024 * 1024
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val trackingInput = ReadSizeTrackingInputStream(ByteArrayInputStream(data))
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(trackingInput, data.size.toLong(), 3, 0L, output)
+
+            // Then
+            assertTrue(trackingInput.maxReadSize <= ChunkedResponseWriter.STREAM_BUFFER_SIZE) {
+                "Maximum read size was ${trackingInput.maxReadSize} bytes, " +
+                    "which exceeds STREAM_BUFFER_SIZE of ${ChunkedResponseWriter.STREAM_BUFFER_SIZE} bytes"
+            }
+            assertArrayEquals(data, output.toByteArray())
+        }
+
+        @Test
+        fun `Given input stream smaller than buffer When writeChunkedFromStream Then read size does not exceed body size`() = runTest {
+            // Given
+            val size = 512 // 512 bytes, well under 1MB
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val trackingInput = ReadSizeTrackingInputStream(ByteArrayInputStream(data))
+            val output = ByteArrayOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(trackingInput, data.size.toLong(), 2, 0L, output)
+
+            // Then
+            assertTrue(trackingInput.maxReadSize <= size) {
+                "Maximum read size was ${trackingInput.maxReadSize} bytes, " +
+                    "which exceeds body size of $size bytes"
+            }
+            assertArrayEquals(data, output.toByteArray())
+        }
+    }
+
+    @Nested
+    inner class FlushBehavior {
+
+        @Test
+        fun `Given 1KB input and 3 chunks When writeChunkedFromStream Then flush is called 3 times`() = runTest {
+            // Given
+            val data = ByteArray(1024) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val flushTrackingOutput = FlushTrackingOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 3, 0L, flushTrackingOutput)
+
+            // Then
+            assertEquals(3, flushTrackingOutput.flushCount)
+        }
+
+        @Test
+        fun `Given 5MB input and 5 chunks When writeChunkedFromStream Then flush is called 5 times`() = runTest {
+            // Given
+            val size = 5 * 1024 * 1024
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val flushTrackingOutput = FlushTrackingOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 5, 0L, flushTrackingOutput)
+
+            // Then
+            assertEquals(5, flushTrackingOutput.flushCount)
+        }
+
+        @Test
+        fun `Given 10MB input and 10 chunks When writeChunkedFromStream Then flush is called 10 times`() = runTest {
+            // Given
+            val size = 10 * 1024 * 1024
+            val data = ByteArray(size) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(data)
+            val flushTrackingOutput = FlushTrackingOutputStream()
+
+            // When
+            writer.writeChunkedFromStream(input, data.size.toLong(), 10, 0L, flushTrackingOutput)
+
+            // Then
+            assertEquals(10, flushTrackingOutput.flushCount)
+        }
+    }
+
+    @Nested
+    inner class CalculateStreamChunkSize {
+
+        @Test
+        fun `Given 0 body size and 5 chunks When calculateStreamChunkSize Then returns 0`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(0L, 5)
+
+            // Then
+            assertEquals(0L, result)
+        }
+
+        @Test
+        fun `Given 10 bytes and 1 chunk When calculateStreamChunkSize Then returns 10`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(10L, 1)
+
+            // Then
+            assertEquals(10L, result)
+        }
+
+        @Test
+        fun `Given 10 bytes and 3 chunks When calculateStreamChunkSize Then returns 4 using ceiling division`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(10L, 3)
+
+            // Then — ceiling(10/3) = 4
+            assertEquals(4L, result)
+        }
+
+        @Test
+        fun `Given 5 bytes and 10 chunks When calculateStreamChunkSize Then returns 1 as minimum chunk size`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(5L, 10)
+
+            // Then — ceiling(5/10) = 1
+            assertEquals(1L, result)
+        }
+
+        @Test
+        fun `Given positive body size and 0 chunks When calculateStreamChunkSize Then returns 0`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(100L, 0)
+
+            // Then
+            assertEquals(0L, result)
+        }
+
+        @Test
+        fun `Given positive body size and negative chunks When calculateStreamChunkSize Then returns 0`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(100L, -1)
+
+            // Then
+            assertEquals(0L, result)
+        }
+
+        @Test
+        fun `Given evenly divisible body size When calculateStreamChunkSize Then returns exact division`() {
+            // Given / When
+            val result = writer.calculateStreamChunkSize(100L, 5)
+
+            // Then — 100/5 = 20 exactly
+            assertEquals(20L, result)
+        }
+    }
+
+    /**
+     * Custom InputStream wrapper that tracks the maximum number of bytes
+     * requested in any single read() call, verifying bounded memory usage.
+     */
+    private class ReadSizeTrackingInputStream(private val delegate: InputStream) : InputStream() {
+        var maxReadSize = 0
+            private set
+
+        override fun read(): Int = delegate.read()
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            if (len > maxReadSize) {
+                maxReadSize = len
+            }
+            return delegate.read(b, off, len)
+        }
+    }
+
+    /**
+     * Custom OutputStream that tracks flush calls for verification.
+     */
+    private class FlushTrackingOutputStream : OutputStream() {
+        private val buffer = ByteArrayOutputStream()
+        var flushCount = 0
+            private set
+
+        override fun write(b: Int) {
+            buffer.write(b)
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            buffer.write(b, off, len)
+        }
+
+        override fun flush() {
+            flushCount++
+            buffer.flush()
+        }
+
+        fun toByteArray(): ByteArray = buffer.toByteArray()
+    }
+}

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterStreamTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ChunkedResponseWriterStreamTest.kt
@@ -196,6 +196,61 @@ class ChunkedResponseWriterStreamTest {
     }
 
     @Nested
+    inner class PrematureEof {
+
+        @Test
+        fun `Given bodySize larger than actual stream content When writeChunkedFromStream Then throws PrematureEofException`() = runTest {
+            // Given - stream has 500 bytes but bodySize claims 1024
+            val actualData = ByteArray(500) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(actualData)
+            val output = ByteArrayOutputStream()
+            val claimedSize = 1024L
+
+            // When / Then
+            val exception = org.junit.jupiter.api.assertThrows<PrematureEofException> {
+                writer.writeChunkedFromStream(input, claimedSize, 3, 0L, output)
+            }
+            assertTrue(exception.message!!.contains("expected 1024 bytes"))
+            assertTrue(exception.message!!.contains("only received 500 bytes"))
+        }
+
+        @Test
+        fun `Given bodySize much larger than actual stream When writeChunkedFromStream Then fails fast without looping`() = runTest {
+            // Given - stream has 100 bytes but bodySize claims 10MB
+            val actualData = ByteArray(100) { (it % 256).toByte() }
+            val input = ByteArrayInputStream(actualData)
+            val output = ByteArrayOutputStream()
+            val claimedSize = 10L * 1024 * 1024
+
+            // When / Then - should throw immediately, not loop forever
+            val startTime = System.currentTimeMillis()
+            val exception = org.junit.jupiter.api.assertThrows<PrematureEofException> {
+                writer.writeChunkedFromStream(input, claimedSize, 5, 0L, output)
+            }
+            val elapsed = System.currentTimeMillis() - startTime
+
+            assertTrue(exception.message!!.contains("expected ${claimedSize} bytes"))
+            assertTrue(exception.message!!.contains("only received 100 bytes"))
+            // Should complete almost instantly (well under 1 second), not loop
+            assertTrue(elapsed < 1000) { "Method took ${elapsed}ms — likely looping instead of failing fast" }
+        }
+
+        @Test
+        fun `Given empty stream with non-zero bodySize When writeChunkedFromStream Then throws PrematureEofException`() = runTest {
+            // Given - empty stream but bodySize claims 512
+            val input = ByteArrayInputStream(ByteArray(0))
+            val output = ByteArrayOutputStream()
+
+            // When / Then
+            val exception = org.junit.jupiter.api.assertThrows<PrematureEofException> {
+                writer.writeChunkedFromStream(input, 512L, 2, 0L, output)
+            }
+            assertTrue(exception.message!!.contains("expected 512 bytes"))
+            assertTrue(exception.message!!.contains("only received 0 bytes"))
+        }
+    }
+
+    @Nested
     inner class CalculateStreamChunkSize {
 
         @Test

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamerTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/S3ResponseStreamerTest.kt
@@ -3,16 +3,21 @@ package nl.vintik.mocknest.infra.aws.runtime.streaming
 import aws.sdk.kotlin.services.s3.S3Client
 import aws.sdk.kotlin.services.s3.model.GetObjectRequest
 import aws.sdk.kotlin.services.s3.model.GetObjectResponse
+import aws.sdk.kotlin.services.s3.model.HeadObjectRequest
+import aws.sdk.kotlin.services.s3.model.HeadObjectResponse
 import aws.smithy.kotlin.runtime.content.ByteStream
 import io.mockk.clearMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -368,6 +373,126 @@ class S3ResponseStreamerTest {
             // Then
             assertFalse(result)
             assertEquals(0, output.size())
+        }
+    }
+
+    @Nested
+    inner class GetContentLength {
+
+        @Test
+        fun `Given existing S3 object When getContentLength Then returns correct size`() = runTest {
+            // Given
+            val s3Key = "__files/existing-object.json"
+            val expectedLength = 12345L
+
+            coEvery { mockS3Client.headObject(any<HeadObjectRequest>()) } returns HeadObjectResponse {
+                contentLength = expectedLength
+            }
+
+            // When
+            val result = streamer.getContentLength(s3Key)
+
+            // Then
+            assertNotNull(result)
+            assertEquals(expectedLength, result)
+            coVerify {
+                mockS3Client.headObject(match<HeadObjectRequest> {
+                    it.bucket == bucketName && it.key == s3Key
+                })
+            }
+        }
+
+        @Test
+        fun `Given non-existing S3 object When getContentLength Then returns null`() = runTest {
+            // Given
+            val s3Key = "__files/non-existing-object.json"
+
+            coEvery { mockS3Client.headObject(any<HeadObjectRequest>()) } throws
+                RuntimeException("NoSuchKey: The specified key does not exist.")
+
+            // When
+            val result = streamer.getContentLength(s3Key)
+
+            // Then
+            assertNull(result)
+        }
+    }
+
+    @Nested
+    inner class StreamWithConsumer {
+
+        @Test
+        fun `Given existing S3 object When streamWithConsumer Then invokes consumer with readable InputStream`() = runTest {
+            // Given
+            val s3Key = "__files/consumer-test.json"
+            val content = """{"status":"ok"}""".toByteArray()
+            var receivedBytes: ByteArray? = null
+
+            coEvery { mockS3Client.getObject(any<GetObjectRequest>(), any<suspend (GetObjectResponse) -> Boolean>()) } coAnswers {
+                val block = secondArg<suspend (GetObjectResponse) -> Boolean>()
+                val response = GetObjectResponse {
+                    body = ByteStream.fromBytes(content)
+                    contentLength = content.size.toLong()
+                }
+                block(response)
+            }
+
+            // When
+            val result = streamer.streamWithConsumer(s3Key) { inputStream, _ ->
+                receivedBytes = inputStream.readAllBytes()
+            }
+
+            // Then
+            assertTrue(result)
+            assertNotNull(receivedBytes)
+            assertArrayEquals(content, receivedBytes)
+        }
+
+        @Test
+        fun `Given non-existing S3 object When streamWithConsumer Then returns false`() = runTest {
+            // Given
+            val s3Key = "__files/missing-object.json"
+            var consumerCalled = false
+
+            coEvery { mockS3Client.getObject(any<GetObjectRequest>(), any<suspend (GetObjectResponse) -> Boolean>()) } throws
+                RuntimeException("NoSuchKey: The specified key does not exist.")
+
+            // When
+            val result = streamer.streamWithConsumer(s3Key) { _, _ ->
+                consumerCalled = true
+            }
+
+            // Then
+            assertFalse(result)
+            assertFalse(consumerCalled, "Consumer should not be called when object doesn't exist")
+        }
+
+        @Test
+        fun `Given existing S3 object When streamWithConsumer Then consumer receives correct contentLength`() = runTest {
+            // Given
+            val s3Key = "__files/length-test.bin"
+            val content = ByteArray(5000) { (it % 256).toByte() }
+            val expectedContentLength = content.size.toLong()
+            var receivedContentLength: Long? = null
+
+            coEvery { mockS3Client.getObject(any<GetObjectRequest>(), any<suspend (GetObjectResponse) -> Boolean>()) } coAnswers {
+                val block = secondArg<suspend (GetObjectResponse) -> Boolean>()
+                val response = GetObjectResponse {
+                    body = ByteStream.fromBytes(content)
+                    contentLength = expectedContentLength
+                }
+                block(response)
+            }
+
+            // When
+            val result = streamer.streamWithConsumer(s3Key) { _, contentLength ->
+                receivedContentLength = contentLength
+            }
+
+            // Then
+            assertTrue(result)
+            assertNotNull(receivedContentLength)
+            assertEquals(expectedContentLength, receivedContentLength)
         }
     }
 

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ZeroMemoryStreamingIntegrationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ZeroMemoryStreamingIntegrationTest.kt
@@ -141,6 +141,11 @@ class ZeroMemoryStreamingIntegrationTest : KoinTest {
         val resetOutput = ByteArrayOutputStream()
         handler.handleRequest(resetInput, resetOutput, mockContext)
 
+        val resetResponse = parseStreamingResponse(resetOutput.toByteArray())
+        check(resetResponse.statusCode == 200) {
+            "tearDown: DELETE /__admin/mappings failed with status ${resetResponse.statusCode}: ${resetResponse.body}"
+        }
+
         runBlocking {
             val keys = storage.list().toList()
             keys.forEach { key -> storage.delete(key) }
@@ -333,8 +338,21 @@ class ZeroMemoryStreamingIntegrationTest : KoinTest {
         body: String,
         numberOfChunks: Int,
         totalDuration: Int,
-    ): String =
-        """{"request":{"url":"$url","method":"GET"},"response":{"status":200,"body":"$body","headers":{"Content-Type":"text/plain"},"chunkedDribbleDelay":{"numberOfChunks":$numberOfChunks,"totalDuration":$totalDuration}}}"""
+    ): String {
+        val mapping = mapOf(
+            "request" to mapOf("url" to url, "method" to "GET"),
+            "response" to mapOf(
+                "status" to numberOfChunks.let { 200 },
+                "body" to body,
+                "headers" to mapOf("Content-Type" to "text/plain"),
+                "chunkedDribbleDelay" to mapOf(
+                    "numberOfChunks" to numberOfChunks,
+                    "totalDuration" to totalDuration,
+                ),
+            ),
+        )
+        return mapper.writeValueAsString(mapping)
+    }
 
     private fun createApiGatewayRequest(
         path: String,

--- a/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ZeroMemoryStreamingIntegrationTest.kt
+++ b/software/infra/aws/runtime/src/test/kotlin/nl/vintik/mocknest/infra/aws/runtime/streaming/ZeroMemoryStreamingIntegrationTest.kt
@@ -1,0 +1,423 @@
+package nl.vintik.mocknest.infra.aws.runtime.streaming
+
+import aws.sdk.kotlin.runtime.auth.credentials.StaticCredentialsProvider
+import aws.sdk.kotlin.services.s3.S3Client
+import aws.sdk.kotlin.services.s3.model.CreateBucketRequest
+import aws.smithy.kotlin.runtime.auth.awscredentials.Credentials
+import aws.smithy.kotlin.runtime.net.url.Url
+import com.amazonaws.services.lambda.runtime.Context
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import nl.vintik.mocknest.application.core.interfaces.storage.ObjectStorageInterface
+import nl.vintik.mocknest.application.core.mapper
+import nl.vintik.mocknest.infra.aws.core.di.KoinBootstrap
+import nl.vintik.mocknest.infra.aws.core.streaming.StreamingProtocolWriter
+import nl.vintik.mocknest.infra.aws.runtime.di.runtimeModule
+import nl.vintik.mocknest.infra.aws.runtime.function.StreamingRuntimeLambdaHandler
+import org.crac.Core
+import org.crac.Resource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.parallel.Isolated
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.koin.test.inject
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import uk.org.webcompere.systemstubs.environment.EnvironmentVariables
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private val logger = KotlinLogging.logger {}
+
+private const val TEST_BUCKET_NAME = "zero-memory-streaming-test-bucket"
+private const val TEST_REGION = "us-east-1"
+
+/**
+ * Integration test for zero-memory S3 streaming with chunked dribble delay.
+ *
+ * Uses a LocalStack container for S3 and a real WireMock server to validate:
+ * - Persistent mock with bodyFileName + chunkedDribbleDelay → handler streams from S3 byte-for-byte
+ * - Small body (<1MB) with dribble → correct delivery
+ * - Medium body (~5MB) with dribble → correct delivery
+ * - Progressive delivery timing (elapsed time >= 80% of totalDuration)
+ * - Inline body dribble mock (persistent: false) still works unchanged
+ *
+ * **Validates: Requirements 7.1, 7.2, 7.3, 7.4**
+ */
+@Isolated
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class ZeroMemoryStreamingIntegrationTest : KoinTest {
+
+    private lateinit var testS3Client: S3Client
+    private lateinit var handler: StreamingRuntimeLambdaHandler
+    private val mockContext: Context = mockk(relaxed = true)
+
+    private val storage: ObjectStorageInterface by inject()
+
+    companion object {
+        private val envVars = EnvironmentVariables()
+
+        private val localStack: LocalStackContainer = LocalStackContainer(
+            DockerImageName.parse("localstack/localstack:4.12.0")
+        ).withServices(LocalStackContainer.Service.S3)
+            .waitingFor(
+                Wait.forHttp("/_localstack/health")
+                    .forStatusCode(200)
+                    .withStartupTimeout(Duration.ofMinutes(2))
+            )
+    }
+
+    @BeforeAll
+    fun setupAll() {
+        localStack.start()
+
+        envVars.set("MOCKNEST_S3_BUCKET_NAME", TEST_BUCKET_NAME)
+        envVars.set("AWS_REGION", TEST_REGION)
+        envVars.set("AWS_DEFAULT_REGION", TEST_REGION)
+        envVars.set("MOCKNEST_WEBHOOK_QUEUE_URL", "")
+        envVars.set("MOCKNEST_SENSITIVE_HEADERS", "Authorization,X-Api-Key")
+        envVars.setup()
+
+        val s3Endpoint = localStack.getEndpointOverride(LocalStackContainer.Service.S3).toString()
+        testS3Client = S3Client {
+            region = TEST_REGION
+            endpointUrl = Url.parse(s3Endpoint)
+            forcePathStyle = true
+            credentialsProvider = StaticCredentialsProvider(
+                Credentials(
+                    accessKeyId = localStack.accessKey,
+                    secretAccessKey = localStack.secretKey,
+                )
+            )
+        }
+
+        runBlocking {
+            testS3Client.runCatching {
+                createBucket(CreateBucketRequest { bucket = TEST_BUCKET_NAME })
+            }.onFailure { exception ->
+                val message = exception.message?.lowercase() ?: ""
+                if (!message.contains("bucketalreadyownedbyyou") && !message.contains("bucketalreadyexists")) {
+                    throw exception
+                }
+            }
+        }
+
+        mockkStatic(Core::class)
+        val mockCracContext: org.crac.Context<Resource> = mockk(relaxed = true)
+        every { Core.getGlobalContext() } returns mockCracContext
+
+        val testCoreModule = module {
+            single { mapper }
+            single { testS3Client }
+        }
+
+        KoinBootstrap.init(listOf(testCoreModule, runtimeModule()))
+        handler = StreamingRuntimeLambdaHandler()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        val resetInput = createApiGatewayRequest("/__admin/mappings", "DELETE")
+        val resetOutput = ByteArrayOutputStream()
+        handler.handleRequest(resetInput, resetOutput, mockContext)
+
+        runBlocking {
+            val keys = storage.list().toList()
+            keys.forEach { key -> storage.delete(key) }
+        }
+    }
+
+    @AfterAll
+    fun tearDownAll() {
+        stopKoin()
+        KoinBootstrap.reset()
+        unmockkAll()
+        envVars.teardown()
+        runBlocking { testS3Client.close() }
+        localStack.stop()
+    }
+
+    @Nested
+    inner class S3StreamingWithChunkedDribbleDelay {
+
+        @Test
+        fun `Given persistent mock with known body and chunkedDribbleDelay When invoked via handler Then complete body received byte-for-byte`() {
+            // Given - register a persistent mock with body + chunkedDribbleDelay
+            // The NormalizeMappingBodyFilter will externalize the body to S3 (bodyFileName)
+            // The ChunkedDribbleDelayCapture transformer will intercept bodyFileName + dribble
+            val expectedBody = "Hello, this is a test body for S3 streaming with chunked dribble delay!"
+            val mappingJson = """
+                {
+                    "request": { "url": "/api/s3-dribble", "method": "GET" },
+                    "response": {
+                        "status": 200,
+                        "body": "${escapeJsonString(expectedBody)}",
+                        "headers": { "Content-Type": "text/plain" },
+                        "chunkedDribbleDelay": {
+                            "numberOfChunks": 3,
+                            "totalDuration": 600
+                        }
+                    }
+                }
+            """.trimIndent()
+            registerMapping(mappingJson)
+
+            // When - invoke the mock endpoint via streaming handler
+            val input = createApiGatewayRequest("/mocknest/api/s3-dribble", "GET")
+            val output = ByteArrayOutputStream()
+            handler.handleRequest(input, output, mockContext)
+
+            // Then - verify complete body received byte-for-byte
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(expectedBody, parsed.body)
+        }
+
+        @Test
+        fun `Given small body less than 1MB with chunkedDribbleDelay When invoked Then correct delivery`() {
+            // Given - small body (~500KB) with chunkedDribbleDelay on a persistent mock
+            val expectedBody = "X".repeat(500 * 1024) // 500KB
+            val mappingJson = buildPersistentDribbleMapping(
+                url = "/api/small-s3-dribble",
+                body = expectedBody,
+                numberOfChunks = 5,
+                totalDuration = 1000,
+            )
+            registerMapping(mappingJson)
+
+            // When
+            val input = createApiGatewayRequest("/mocknest/api/small-s3-dribble", "GET")
+            val output = ByteArrayOutputStream()
+            handler.handleRequest(input, output, mockContext)
+
+            // Then - verify correct delivery
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(expectedBody.length, parsed.body.length)
+            assertEquals(expectedBody, parsed.body)
+        }
+
+        @Test
+        fun `Given medium body around 5MB with chunkedDribbleDelay When invoked Then correct delivery`() {
+            // Given - medium body (~5MB) with chunkedDribbleDelay on a persistent mock
+            val expectedBody = "Y".repeat(5 * 1024 * 1024) // 5MB
+            val mappingJson = buildPersistentDribbleMapping(
+                url = "/api/medium-s3-dribble",
+                body = expectedBody,
+                numberOfChunks = 5,
+                totalDuration = 1000,
+            )
+            registerMapping(mappingJson)
+
+            // When
+            val input = createApiGatewayRequest("/mocknest/api/medium-s3-dribble", "GET")
+            val output = ByteArrayOutputStream()
+            handler.handleRequest(input, output, mockContext)
+
+            // Then - verify correct delivery byte-for-byte
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(expectedBody.length, parsed.body.length)
+            assertEquals(expectedBody, parsed.body)
+        }
+
+        @Test
+        fun `Given persistent mock with chunkedDribbleDelay When invoked Then delivery timing is progressive`() {
+            // Given - persistent mock with body + chunkedDribbleDelay with measurable duration
+            // Use 10 chunks with 3000ms total so delay between chunks = 300ms
+            // Expected elapsed >= 80% of 3000ms = 2400ms
+            val expectedBody = "Z".repeat(10 * 1024) // 10KB - small enough to not dominate timing
+            val mappingJson = buildPersistentDribbleMapping(
+                url = "/api/timed-s3-dribble",
+                body = expectedBody,
+                numberOfChunks = 10,
+                totalDuration = 3000,
+            )
+            registerMapping(mappingJson)
+
+            // When - invoke and measure delivery time
+            val input = createApiGatewayRequest("/mocknest/api/timed-s3-dribble", "GET")
+            val output = ByteArrayOutputStream()
+            val startTime = System.currentTimeMillis()
+            handler.handleRequest(input, output, mockContext)
+            val elapsedTime = System.currentTimeMillis() - startTime
+
+            // Then - verify body is complete
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(expectedBody, parsed.body)
+
+            // Verify delivery timing is progressive (elapsed time >= 80% of totalDuration)
+            val minimumExpectedTime = (3000 * 0.80).toLong() // 2400ms
+            logger.info { "S3 dribble delivery time: ${elapsedTime}ms (minimum expected: ${minimumExpectedTime}ms)" }
+            assertTrue(
+                elapsedTime >= minimumExpectedTime,
+                "Delivery time ${elapsedTime}ms should be at least 80% of 3000ms (${minimumExpectedTime}ms)"
+            )
+        }
+
+        @Test
+        fun `Given inline body dribble mock with persistent false When invoked Then still works unchanged`() {
+            // Given - inline body mock (persistent: false) with chunkedDribbleDelay
+            // This should NOT go through the S3 streaming path
+            val sseBody = "data: event1\\ndata: event2\\ndata: event3\\n"
+            val expectedBody = "data: event1\ndata: event2\ndata: event3\n"
+            val mappingJson = """
+                {
+                    "persistent": false,
+                    "request": { "url": "/api/inline-dribble", "method": "GET" },
+                    "response": {
+                        "status": 200,
+                        "body": "$sseBody",
+                        "headers": { "Content-Type": "text/event-stream" },
+                        "chunkedDribbleDelay": {
+                            "numberOfChunks": 3,
+                            "totalDuration": 600
+                        }
+                    }
+                }
+            """.trimIndent()
+            registerMapping(mappingJson)
+
+            // When
+            val input = createApiGatewayRequest("/mocknest/api/inline-dribble", "GET")
+            val output = ByteArrayOutputStream()
+            handler.handleRequest(input, output, mockContext)
+
+            // Then - verify inline body dribble still works correctly
+            val parsed = parseStreamingResponse(output.toByteArray())
+            assertEquals(200, parsed.statusCode)
+            assertEquals(expectedBody, parsed.body)
+        }
+    }
+
+    // --- Helper methods ---
+
+    private fun registerMapping(mappingJson: String) {
+        val input = createApiGatewayRequest(
+            path = "/__admin/mappings",
+            httpMethod = "POST",
+            body = mappingJson,
+            headers = mapOf("Content-Type" to "application/json"),
+        )
+        val output = ByteArrayOutputStream()
+        handler.handleRequest(input, output, mockContext)
+
+        val parsed = parseStreamingResponse(output.toByteArray())
+        assertEquals(201, parsed.statusCode, "Failed to register mapping: ${parsed.body}")
+        logger.info { "Mapping registered successfully" }
+    }
+
+    private fun buildPersistentDribbleMapping(
+        url: String,
+        body: String,
+        numberOfChunks: Int,
+        totalDuration: Int,
+    ): String =
+        """{"request":{"url":"$url","method":"GET"},"response":{"status":200,"body":"$body","headers":{"Content-Type":"text/plain"},"chunkedDribbleDelay":{"numberOfChunks":$numberOfChunks,"totalDuration":$totalDuration}}}"""
+
+    private fun createApiGatewayRequest(
+        path: String,
+        httpMethod: String,
+        headers: Map<String, String> = mapOf("Accept" to "application/json"),
+        body: String? = null,
+        isBase64Encoded: Boolean = false,
+        queryParameters: Map<String, String> = emptyMap(),
+    ): ByteArrayInputStream {
+        val headersJson = headers.entries.joinToString(",") { (k, v) ->
+            """"${escapeJsonString(k)}":"${escapeJsonString(v)}""""
+        }
+        val queryParamsJson = if (queryParameters.isEmpty()) {
+            "{}"
+        } else {
+            queryParameters.entries.joinToString(",", "{", "}") { (k, v) ->
+                """"${escapeJsonString(k)}":"${escapeJsonString(v)}""""
+            }
+        }
+        val bodyJson = if (body != null) {
+            "\"${escapeJsonString(body)}\""
+        } else {
+            "null"
+        }
+        val json = """{
+            "httpMethod": "$httpMethod",
+            "path": "$path",
+            "headers": {$headersJson},
+            "queryStringParameters": $queryParamsJson,
+            "body": $bodyJson,
+            "isBase64Encoded": $isBase64Encoded
+        }"""
+        return ByteArrayInputStream(json.toByteArray())
+    }
+
+    private fun escapeJsonString(value: String): String =
+        value.replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+
+    private fun parseStreamingResponse(bytes: ByteArray): ParsedStreamingResponse {
+        val delimiterIndex = findNullDelimiter(bytes)
+        check(delimiterIndex >= 0) { "No 8 null byte delimiter found in streaming response" }
+
+        val metadataBytes = bytes.copyOfRange(0, delimiterIndex)
+        val metadataJson = String(metadataBytes, Charsets.UTF_8)
+        val metadata = Json.parseToJsonElement(metadataJson).jsonObject
+
+        val statusCode = metadata["statusCode"]?.jsonPrimitive?.int
+            ?: error("Missing statusCode in metadata")
+
+        val headersObj = metadata["headers"]?.jsonObject ?: JsonObject(emptyMap())
+        val headers = headersObj.entries.associate { (k, v) -> k to v.jsonPrimitive.content }
+
+        val bodyBytes = bytes.copyOfRange(
+            delimiterIndex + StreamingProtocolWriter.NULL_DELIMITER_SIZE,
+            bytes.size,
+        )
+        val body = String(bodyBytes, Charsets.UTF_8)
+
+        return ParsedStreamingResponse(statusCode, headers, body)
+    }
+
+    private fun findNullDelimiter(bytes: ByteArray): Int {
+        val delimiterSize = StreamingProtocolWriter.NULL_DELIMITER_SIZE
+        for (i in 0..bytes.size - delimiterSize) {
+            var allNull = true
+            for (j in 0 until delimiterSize) {
+                if (bytes[i + j] != 0.toByte()) {
+                    allNull = false
+                    break
+                }
+            }
+            if (allNull) return i
+        }
+        return -1
+    }
+
+    private data class ParsedStreamingResponse(
+        val statusCode: Int,
+        val headers: Map<String, String>,
+        val body: String,
+    )
+}


### PR DESCRIPTION
## Summary
do not load dribble payload into memory

## Related Issues
<!-- Reference any related issues: Fixes #123, Relates to #456 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * S3-backed streaming for chunked "dribble" responses; supports streaming bodies referenced by external file names.
  * Stream-based chunked writer with robust EOF handling and configurable chunk sizing.

* **Behavior**
  * Streaming validates S3 object size before streaming and preserves existing response-size limits for non-streamed paths.
  * On streaming, response metadata is emitted before body and failures are logged while preserving protocol semantics.

* **Tests**
  * Extensive unit, property, and integration tests covering S3 routing, stream writing, EOF/error cases, and timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/elenavanengelenmaslova/mocknest-serverless/pull/238?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->